### PR TITLE
inclusion exclusion criteria

### DIFF
--- a/examples/iedb/tsv/investigations.tsv
+++ b/examples/iedb/tsv/investigations.tsv
@@ -1,2 +1,2 @@
-akc_id	name	description	study_type	archival_id	inclusion_criteria	exclusion_criteria	release_date	update_date	participants	assays	simulations	documents	conclusions
-AKC:1	Identifying specificity groups in the T cell receptor repertoire.				[]	[]			[]	[]	[]	[]	[]
+akc_id	name	description	study_type	archival_id	inclusion_exclusion_criteria	release_date	update_date	participants	assays	simulations	documents	conclusions
+AKC:1	Identifying specificity groups in the T cell receptor repertoire.							[]	[]	[]	[]	[]

--- a/examples/iedb/tsv/study_arms.tsv
+++ b/examples/iedb/tsv/study_arms.tsv
@@ -1,22 +1,22 @@
-akc_id	name	description	investigation	inclusion_criteria	exclusion_criteria
-AKC:2	arm 1 of 3480642	study arm for assay 3480642	AKC:1	[]	[]
-AKC:12	arm 1 of 3480639	study arm for assay 3480639	AKC:1	[]	[]
-AKC:22	arm 1 of 3480641	study arm for assay 3480641	AKC:1	[]	[]
-AKC:32	arm 1 of 3480644	study arm for assay 3480644	AKC:1	[]	[]
-AKC:42	arm 1 of 3480640	study arm for assay 3480640	AKC:1	[]	[]
-AKC:52	arm 1 of 3480643	study arm for assay 3480643	AKC:1	[]	[]
-AKC:62	arm 1 of 3480645	study arm for assay 3480645	AKC:1	[]	[]
-AKC:72	arm 1 of 3480646	study arm for assay 3480646	AKC:1	[]	[]
-AKC:82	arm 1 of 3480647	study arm for assay 3480647	AKC:1	[]	[]
-AKC:92	arm 1 of 3480649	study arm for assay 3480649	AKC:1	[]	[]
-AKC:102	arm 1 of 3480650	study arm for assay 3480650	AKC:1	[]	[]
-AKC:112	arm 1 of 3480651	study arm for assay 3480651	AKC:1	[]	[]
-AKC:122	arm 1 of 3480655	study arm for assay 3480655	AKC:1	[]	[]
-AKC:132	arm 1 of 3480656	study arm for assay 3480656	AKC:1	[]	[]
-AKC:142	arm 1 of 3480658	study arm for assay 3480658	AKC:1	[]	[]
-AKC:152	arm 1 of 3480659	study arm for assay 3480659	AKC:1	[]	[]
-AKC:162	arm 1 of 3480660	study arm for assay 3480660	AKC:1	[]	[]
-AKC:172	arm 1 of 3480661	study arm for assay 3480661	AKC:1	[]	[]
-AKC:182	arm 1 of 3480662	study arm for assay 3480662	AKC:1	[]	[]
-AKC:192	arm 1 of 3480663	study arm for assay 3480663	AKC:1	[]	[]
-AKC:202	arm 1 of 3480664	study arm for assay 3480664	AKC:1	[]	[]
+akc_id	name	description	investigation
+AKC:2	arm 1 of 3480642	study arm for assay 3480642	AKC:1
+AKC:12	arm 1 of 3480639	study arm for assay 3480639	AKC:1
+AKC:22	arm 1 of 3480641	study arm for assay 3480641	AKC:1
+AKC:32	arm 1 of 3480644	study arm for assay 3480644	AKC:1
+AKC:42	arm 1 of 3480640	study arm for assay 3480640	AKC:1
+AKC:52	arm 1 of 3480643	study arm for assay 3480643	AKC:1
+AKC:62	arm 1 of 3480645	study arm for assay 3480645	AKC:1
+AKC:72	arm 1 of 3480646	study arm for assay 3480646	AKC:1
+AKC:82	arm 1 of 3480647	study arm for assay 3480647	AKC:1
+AKC:92	arm 1 of 3480649	study arm for assay 3480649	AKC:1
+AKC:102	arm 1 of 3480650	study arm for assay 3480650	AKC:1
+AKC:112	arm 1 of 3480651	study arm for assay 3480651	AKC:1
+AKC:122	arm 1 of 3480655	study arm for assay 3480655	AKC:1
+AKC:132	arm 1 of 3480656	study arm for assay 3480656	AKC:1
+AKC:142	arm 1 of 3480658	study arm for assay 3480658	AKC:1
+AKC:152	arm 1 of 3480659	study arm for assay 3480659	AKC:1
+AKC:162	arm 1 of 3480660	study arm for assay 3480660	AKC:1
+AKC:172	arm 1 of 3480661	study arm for assay 3480661	AKC:1
+AKC:182	arm 1 of 3480662	study arm for assay 3480662	AKC:1
+AKC:192	arm 1 of 3480663	study arm for assay 3480663	AKC:1
+AKC:202	arm 1 of 3480664	study arm for assay 3480664	AKC:1

--- a/project/jsonld/ak_schema.jsonld
+++ b/project/jsonld/ak_schema.jsonld
@@ -1831,11 +1831,6 @@
       "description": "Participants in an investigation must meet this criteria",
       "from_schema": "https://github.com/airr-knowledge/ak-schema",
       "slot_uri": "https://github.com/airr-knowledge/ak-schema/inclusion_criteria",
-      "owner": "StudyArm",
-      "domain_of": [
-        "Investigation",
-        "StudyArm"
-      ],
       "range": "string",
       "multivalued": true,
       "@type": "SlotDefinition"
@@ -1846,11 +1841,6 @@
       "description": "Participants are excluded from an investigation if they meet this criteria",
       "from_schema": "https://github.com/airr-knowledge/ak-schema",
       "slot_uri": "https://github.com/airr-knowledge/ak-schema/exclusion_criteria",
-      "owner": "StudyArm",
-      "domain_of": [
-        "Investigation",
-        "StudyArm"
-      ],
       "range": "string",
       "multivalued": true,
       "@type": "SlotDefinition"
@@ -5248,6 +5238,7 @@
       "slot_uri": "https://github.com/airr-knowledge/ak-schema/inclusion_exclusion_criteria",
       "owner": "Study",
       "domain_of": [
+        "Investigation",
         "Study"
       ],
       "range": "string",
@@ -11668,8 +11659,7 @@
         "description",
         "study_type",
         "archival_id",
-        "inclusion_criteria",
-        "exclusion_criteria",
+        "inclusion_exclusion_criteria",
         "release_date",
         "update_date",
         "participants",
@@ -11720,9 +11710,7 @@
         "akc_id",
         "name",
         "description",
-        "investigation",
-        "inclusion_criteria",
-        "exclusion_criteria"
+        "investigation"
       ],
       "slot_usage": {},
       "class_uri": "http://purl.obolibrary.org/obo/OBI_0000181",
@@ -13332,9 +13320,9 @@
   ],
   "metamodel_version": "1.7.0",
   "source_file": "ak_schema.yaml",
-  "source_file_date": "2025-03-12T22:22:16",
-  "source_file_size": 196941,
-  "generation_date": "2025-03-12T22:22:18",
+  "source_file_date": "2025-03-12T23:44:04",
+  "source_file_size": 196876,
+  "generation_date": "2025-03-12T23:44:07",
   "@type": "SchemaDefinition",
   "@context": [
     "project/jsonld/ak_schema.context.jsonld",

--- a/project/jsonschema/ak_schema.schema.json
+++ b/project/jsonschema/ak_schema.schema.json
@@ -3508,23 +3508,10 @@
                         "null"
                     ]
                 },
-                "exclusion_criteria": {
-                    "description": "Participants are excluded from an investigation if they meet this criteria",
-                    "items": {
-                        "type": "string"
-                    },
+                "inclusion_exclusion_criteria": {
+                    "description": "List of criteria for inclusion/exclusion for the study",
                     "type": [
-                        "array",
-                        "null"
-                    ]
-                },
-                "inclusion_criteria": {
-                    "description": "Participants in an investigation must meet this criteria",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -3634,23 +3621,10 @@
                         "null"
                     ]
                 },
-                "exclusion_criteria": {
-                    "description": "Participants are excluded from an investigation if they meet this criteria",
-                    "items": {
-                        "type": "string"
-                    },
+                "inclusion_exclusion_criteria": {
+                    "description": "List of criteria for inclusion/exclusion for the study",
                     "type": [
-                        "array",
-                        "null"
-                    ]
-                },
-                "inclusion_criteria": {
-                    "description": "Participants in an investigation must meet this criteria",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -7429,26 +7403,6 @@
                         "null"
                     ]
                 },
-                "exclusion_criteria": {
-                    "description": "Participants are excluded from an investigation if they meet this criteria",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array",
-                        "null"
-                    ]
-                },
-                "inclusion_criteria": {
-                    "description": "Participants in an investigation must meet this criteria",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array",
-                        "null"
-                    ]
-                },
                 "investigation": {
                     "description": "An investigation in which the study arm participates",
                     "type": [
@@ -7482,26 +7436,6 @@
                     "description": "A human-readable description for a thing",
                     "type": [
                         "string",
-                        "null"
-                    ]
-                },
-                "exclusion_criteria": {
-                    "description": "Participants are excluded from an investigation if they meet this criteria",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array",
-                        "null"
-                    ]
-                },
-                "inclusion_criteria": {
-                    "description": "Participants in an investigation must meet this criteria",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array",
                         "null"
                     ]
                 },

--- a/project/linkml/ak_schema.yaml
+++ b/project/linkml/ak_schema.yaml
@@ -5625,8 +5625,7 @@ classes:
     slots:
     - study_type
     - archival_id
-    - inclusion_criteria
-    - exclusion_criteria
+    - inclusion_exclusion_criteria
     - release_date
     - update_date
     - participants
@@ -5658,8 +5657,6 @@ classes:
     is_a: NamedThing
     slots:
     - investigation
-    - inclusion_criteria
-    - exclusion_criteria
     class_uri: OBI:0000181
   Participant:
     name: Participant

--- a/project/owl/ak_schema.owl.ttl
+++ b/project/owl/ak_schema.owl.ttl
@@ -24,68 +24,74 @@ ak_schema:AIRRKnowledgeCommons a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "AIRRKnowledgeCommons" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:StudyArm ;
-            owl:onProperty ak_schema:study_arms ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:conclusions ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Reference ;
-            owl:onProperty ak_schema:references ],
+            owl:allValuesFrom ak_schema:StudyEvent ;
+            owl:onProperty ak_schema:study_events ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:assays ],
+            owl:onProperty ak_schema:specimens ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:specimen_processings ],
+            owl:allValuesFrom ak_schema:Dataset ;
+            owl:onProperty ak_schema:datasets ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:AlphaBetaTCR ;
-            owl:onProperty ak_schema:ab_tcell_receptors ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:gd_tcell_receptors ],
+            owl:allValuesFrom ak_schema:ImmuneExposure ;
+            owl:onProperty ak_schema:immune_exposures ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Investigation ;
             owl:onProperty ak_schema:investigations ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:participants ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Assessment ;
-            owl:onProperty ak_schema:assessments ],
+            owl:onProperty ak_schema:study_events ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:datasets ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:conclusions ],
+            owl:allValuesFrom ak_schema:Chain ;
+            owl:onProperty ak_schema:chains ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Participant ;
+            owl:onProperty ak_schema:participants ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:AlphaBetaTCR ;
+            owl:onProperty ak_schema:ab_tcell_receptors ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:investigations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:study_events ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:LifeEvent ;
-            owl:onProperty ak_schema:life_events ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:life_events ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SpecimenCollection ;
-            owl:onProperty ak_schema:specimen_collections ],
+            owl:onProperty ak_schema:immune_exposures ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:bcell_receptors ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:specimen_collections ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Dataset ;
-            owl:onProperty ak_schema:datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Participant ;
             owl:onProperty ak_schema:participants ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:GammaDeltaTCR ;
-            owl:onProperty ak_schema:gd_tcell_receptors ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:references ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:assessments ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:BCellReceptor ;
+            owl:onProperty ak_schema:bcell_receptors ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Conclusion ;
+            owl:onProperty ak_schema:conclusions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:study_arms ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:epitopes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:investigations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:SpecimenProcessing ;
+            owl:onProperty ak_schema:specimen_processings ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Reference ;
+            owl:onProperty ak_schema:references ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Assay ;
             owl:onProperty ak_schema:assays ],
@@ -93,50 +99,44 @@ ak_schema:AIRRKnowledgeCommons a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:ab_tcell_receptors ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:references ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:chains ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:specimens ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:immune_exposures ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:study_arms ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:assessments ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Chain ;
-            owl:onProperty ak_schema:chains ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Specimen ;
             owl:onProperty ak_schema:specimens ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:epitopes ],
+            owl:onProperty ak_schema:chains ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:ImmuneExposure ;
-            owl:onProperty ak_schema:immune_exposures ],
+            owl:allValuesFrom ak_schema:Assessment ;
+            owl:onProperty ak_schema:assessments ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Conclusion ;
-            owl:onProperty ak_schema:conclusions ],
+            owl:allValuesFrom ak_schema:GammaDeltaTCR ;
+            owl:onProperty ak_schema:gd_tcell_receptors ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SpecimenProcessing ;
-            owl:onProperty ak_schema:specimen_processings ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:specimen_collections ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:StudyEvent ;
-            owl:onProperty ak_schema:study_events ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:gd_tcell_receptors ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:BCellReceptor ;
-            owl:onProperty ak_schema:bcell_receptors ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:assays ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:StudyArm ;
+            owl:onProperty ak_schema:study_arms ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:LifeEvent ;
+            owl:onProperty ak_schema:life_events ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:SpecimenCollection ;
+            owl:onProperty ak_schema:specimen_collections ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Epitope ;
-            owl:onProperty ak_schema:epitopes ] ;
+            owl:onProperty ak_schema:epitopes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:life_events ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:specimen_processings ] ;
     skos:definition "A container for instances of multiple classes." ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -156,131 +156,131 @@ ak_schema:Alignment a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Alignment" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:germline_end ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:support ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:germline_start ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:identity ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:data_processing_id ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:germline_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:score ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:segment ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:score ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cigar ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequence_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:sequence_start ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:rank ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:sequence_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:score ],
+            owl:onProperty ak_schema:call ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:data_processing_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:germline_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:support ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:support ],
+            owl:onProperty ak_schema:call ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:boolean ;
             owl:onProperty ak_schema:rev_comp ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cigar ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:identity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:support ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:rank ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:rev_comp ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:identity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:germline_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:rev_comp ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:call ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:data_processing_id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:germline_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:support ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequence_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:sequence_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:call ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:score ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:identity ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:rank ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:germline_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:sequence_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:score ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cigar ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:germline_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:rank ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:identity ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:germline_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cigar ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:rev_comp ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:sequence_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:segment ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:segment ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:cigar ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:support ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:germline_start ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_start ],
+            owl:onProperty ak_schema:segment ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:segment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:segment ],
+            owl:onProperty ak_schema:sequence_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:rank ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:score ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:identity ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:data_processing_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:data_processing_id ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -292,76 +292,76 @@ ak_schema:Cell a owl:Class,
             owl:onProperty ak_schema:expression_index ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:data_processing_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:ExpressionStudyMethodEnum ;
-            owl:onProperty ak_schema:expression_study_method ],
+            owl:onProperty ak_schema:expression_raw_doi ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:repertoire_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:rearrangements ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:receptors ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:expression_study_method ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:expression_raw_doi ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:expression_index ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cell_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:virtual_pairing ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:data_processing_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:expression_index ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:expression_study_method ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:expression_raw_doi ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:data_processing_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:ExpressionStudyMethodEnum ;
+            owl:onProperty ak_schema:expression_study_method ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:rearrangements ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:data_processing_id ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:boolean ;
             owl:onProperty ak_schema:virtual_pairing ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:expression_raw_doi ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:expression_raw_doi ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:expression_index ],
+            owl:onProperty ak_schema:receptors ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:virtual_pairing ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:expression_index ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:expression_study_method ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:virtual_pairing ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:receptors ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:expression_study_method ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:rearrangements ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:rearrangements ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:data_processing_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:expression_raw_doi ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:receptors ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -369,68 +369,68 @@ ak_schema:CellExpression a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CellExpression" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:property_value ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:expression_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:data_processing_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:property_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:property ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:property_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:property ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:property_value ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:property_value ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:expression_id ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:data_processing_id ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:property_type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:data_processing_id ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:expression_id ],
+            owl:onProperty ak_schema:property_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:PropertyOntology ;
             owl:onProperty ak_schema:property ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:property ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:property_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:property ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_id ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:cell_id ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:cell_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:expression_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:property_value ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:property_value ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:data_processing_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:expression_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:expression_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:property_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:repertoire_id ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -439,103 +439,103 @@ ak_schema:CellIsolationProcessing a owl:Class,
     rdfs:label "CellIsolationProcessing" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_quality ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cells_per_reaction ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_number ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cells_per_reaction ],
+            owl:onProperty ak_schema:cell_storage ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:CellSubsetOntology ;
             owl:onProperty ak_schema:cell_subset ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_quality ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ak_schema:boolean ;
             owl:onProperty ak_schema:cell_storage ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:cell_subset ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_phenotype ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cell_processing_protocol ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_subset ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:cell_quality ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_isolation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_species ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:single_cell ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cells_per_reaction ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:tissue_processing ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:cell_isolation ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:boolean ;
+            owl:onProperty ak_schema:single_cell ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_phenotype ],
+            owl:onProperty ak_schema:tissue_processing ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_subset ],
+            owl:onProperty ak_schema:cell_number ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_processing_protocol ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:cells_per_reaction ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:single_cell ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:tissue_processing ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_processing_protocol ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:cell_phenotype ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:tissue_processing ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_storage ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_species ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:boolean ;
-            owl:onProperty ak_schema:cell_storage ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:single_cell ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:cell_number ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_processing_protocol ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:cell_isolation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_isolation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_species ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:CellSpeciesOntology ;
-            owl:onProperty ak_schema:cell_species ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:cell_number ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cell_quality ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_species ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cell_phenotype ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_quality ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_phenotype ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cells_per_reaction ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:cell_processing_protocol ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:tissue_processing ],
+            owl:allValuesFrom ak_schema:CellSpeciesOntology ;
+            owl:onProperty ak_schema:cell_species ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:boolean ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:single_cell ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_storage ],
         ak_schema:SpecimenProcessing ;
     skos:exactMatch OBI:00000512 ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -544,22 +544,55 @@ ak_schema:CellProcessing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CellProcessing" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_processing_protocol ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cells_per_reaction ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cell_phenotype ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_species ],
+            owl:onProperty ak_schema:cell_processing_protocol ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_phenotype ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_phenotype ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:tissue_processing ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cell_processing_protocol ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_isolation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:single_cell ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_quality ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:tissue_processing ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_storage ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:cells_per_reaction ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cell_number ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_species ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:tissue_processing ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_subset ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_number ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:cell_quality ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -568,80 +601,47 @@ ak_schema:CellProcessing a owl:Class,
             owl:allValuesFrom ak_schema:CellSpeciesOntology ;
             owl:onProperty ak_schema:cell_species ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_storage ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_number ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:CellSubsetOntology ;
             owl:onProperty ak_schema:cell_subset ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:single_cell ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_processing_protocol ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_isolation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_processing_protocol ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:boolean ;
-            owl:onProperty ak_schema:cell_storage ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:boolean ;
-            owl:onProperty ak_schema:single_cell ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:tissue_processing ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_isolation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_subset ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:cell_number ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_quality ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:single_cell ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_processing_protocol ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:tissue_processing ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:cells_per_reaction ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_phenotype ],
+            owl:allValuesFrom ak_schema:boolean ;
+            owl:onProperty ak_schema:single_cell ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_storage ],
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cell_number ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_isolation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:cell_subset ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_storage ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:cell_isolation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:cell_quality ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:boolean ;
+            owl:onProperty ak_schema:cell_storage ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:tissue_processing ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_phenotype ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_phenotype ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cells_per_reaction ],
+            owl:onProperty ak_schema:single_cell ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -649,10 +649,10 @@ ak_schema:ChainSimilarity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ChainSimilarity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:chain_similarity_type ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:chain_similarity_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:ChainSimilarityTypeEnum ;
@@ -665,217 +665,217 @@ ak_schema:Clone a owl:Class,
     rdfs:label "Clone" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:junction_aa_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:clone_id ],
+            owl:onProperty ak_schema:j_call ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:junction_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:junction_aa ],
+            owl:onProperty ak_schema:v_alignment_start ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:clone_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d_alignment_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:junction_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:junction_start ],
+            owl:onProperty ak_schema:j_alignment_end ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:junction_aa_length ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:junction_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_alignment_end ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:germline_alignment_aa ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:junction ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:germline_alignment_aa ],
+            owl:onProperty ak_schema:j_alignment_end ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_call ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:junction_aa ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:junction_aa ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:clone_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:d_call ],
+            owl:onProperty ak_schema:v_alignment_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_alignment_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:j_alignment_start ],
+            owl:onProperty ak_schema:clone_id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_alignment_end ],
+            owl:onProperty ak_schema:data_processing_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequences ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:junction_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:junction_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_alignment_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:junction_length ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:clone_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:junction_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:germline_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:umi_count ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:germline_alignment ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_alignment_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:junction_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:seed_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:seed_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_call ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:v_call ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:sequences ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_alignment_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:seed_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_alignment_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_alignment_end ],
+            owl:onProperty ak_schema:j_call ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:junction_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:seed_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:v_alignment_start ],
+            owl:onProperty ak_schema:d_alignment_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:germline_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:d_alignment_end ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:v_call ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:data_processing_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_alignment_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:j_call ],
+            owl:onProperty ak_schema:d_call ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:repertoire_id ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:junction_start ],
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:clone_count ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:data_processing_id ],
+            owl:onProperty ak_schema:umi_count ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:junction_length ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:j_alignment_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequences ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:germline_alignment_aa ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:junction_end ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:seed_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_call ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_alignment_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:clone_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_alignment_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:umi_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_call ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:j_alignment_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:data_processing_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:clone_count ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:d_alignment_start ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_alignment_start ],
+            owl:onProperty ak_schema:d_call ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:junction_length ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:repertoire_id ],
+            owl:onProperty ak_schema:junction_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:junction_aa_length ],
+            owl:onProperty ak_schema:umi_count ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:junction_aa ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:j_call ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:junction_start ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:junction ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:seed_id ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:v_alignment_end ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:junction_aa_length ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:data_processing_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_call ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:germline_alignment ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:clone_id ],
+            owl:onProperty ak_schema:clone_count ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_alignment_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_alignment_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_alignment_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:junction ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:junction ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:umi_count ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_call ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:umi_count ],
+            owl:onProperty ak_schema:v_alignment_start ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_call ],
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:j_alignment_start ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:germline_alignment ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:clone_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:clone_count ],
+            owl:onProperty ak_schema:j_alignment_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:junction_aa_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_alignment_start ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -896,152 +896,152 @@ ak_schema:GermlineSet a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "GermlineSet" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:species ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:germline_set_name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:species_subgroup ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:species_subgroup_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:LocusEnum ;
             owl:onProperty ak_schema:locus ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:acknowledgements ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:germline_set_ref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:author ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:allele_descriptions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:pub_ids ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:author ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:release_version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:germline_set_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:lab_address ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:germline_set_ref ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:release_description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:lab_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:AlleleDescription ;
-            owl:onProperty ak_schema:allele_descriptions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:germline_set_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:pub_ids ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:lab_address ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:species ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:germline_set_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:curation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:germline_set_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:species_subgroup_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:author ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:release_version ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:germline_set_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:curation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:lab_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Acknowledgement ;
-            owl:onProperty ak_schema:acknowledgements ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:pub_ids ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:release_description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:species_subgroup ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:datetime ;
-            owl:onProperty ak_schema:release_date ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:SpeciesSubgroupTypeEnum ;
             owl:onProperty ak_schema:species_subgroup_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:release_date ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:species_subgroup ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:release_description ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:lab_name ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:pub_ids ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SpeciesOntology ;
-            owl:onProperty ak_schema:species ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:curation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:species_subgroup_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:pub_ids ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:locus ],
+            owl:onProperty ak_schema:species_subgroup_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:release_version ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:release_date ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:lab_address ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:germline_set_ref ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:species_subgroup ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:lab_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:locus ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:germline_set_id ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:release_description ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:germline_set_ref ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:lab_name ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:curation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:pub_ids ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:curation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:release_date ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:author ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:germline_set_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:germline_set_ref ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:species ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:germline_set_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:germline_set_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:allele_descriptions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:release_version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:species_subgroup ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:lab_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:release_date ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:germline_set_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:release_description ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:lab_address ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:AlleleDescription ;
+            owl:onProperty ak_schema:allele_descriptions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:lab_address ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Acknowledgement ;
+            owl:onProperty ak_schema:acknowledgements ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:species ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:SpeciesOntology ;
+            owl:onProperty ak_schema:species ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:author ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:species_subgroup ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:LocusEnum ;
+            owl:onProperty ak_schema:locus ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:datetime ;
+            owl:onProperty ak_schema:release_date ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:acknowledgements ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:release_version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:lab_address ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:author ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -1077,1373 +1077,1373 @@ ak_schema:Rearrangement a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Rearrangement" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:c_call ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_sequence_alignment ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr4_end ],
+            owl:onProperty ak_schema:c_cigar ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:j_support ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:germline_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr3_start ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr3_end ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:j_sequence_start ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:c_alignment_end ],
+            owl:onProperty ak_schema:d_germline_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:p3d2_length ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_frameshift ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_score ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_frame ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:np3_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:p5j_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_cigar ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_germline_end ],
+            owl:onProperty ak_schema:cell_id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:rev_comp ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_cigar ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_sequence_alignment ],
+            owl:onProperty ak_schema:v_sequence_start ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:duplicate_count ],
+            owl:onProperty ak_schema:d_sequence_start ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cdr3_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:stop_codon ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr1 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr4_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:j_alignment_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_call ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:c_support ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr2_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_call ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr4 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:np3_length ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr1_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr1_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_alignment_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_score ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:duplicate_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:n3_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:p3d2_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_germline_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr3_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_identity ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr3_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_call ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_alignment_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:d_sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr1_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:v_germline_alignment ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_alignment_end ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cdr1_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d2_sequence_end ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:np2_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:boolean ;
-            owl:onProperty ak_schema:j_frameshift ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_alignment_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:j_sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:germline_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_identity ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:v_score ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:p3d_length ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:np3 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_identity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_identity ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d2_frame ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_sequence_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:junction_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d_alignment_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_frameshift ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_alignment_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:umi_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:consensus_count ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_frame ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:p3v_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_support ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:junction_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_identity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_support ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_germline_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr2_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_score ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr2_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_alignment_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_support ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:p5d_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr3_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_germline_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:j_score ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_support ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:np1 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_alignment_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr2_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:np1 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d_sequence_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:junction_length ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr1_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequence_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:np1_length ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:np3_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_support ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr2_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:np3_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr1_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:v_call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:n3_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d_frame ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:p3v_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:c_sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_germline_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_support ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_call ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sample_processing_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:v_sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:c_sequence_alignment ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_germline_alignment ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:c_germline_alignment ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:v_sequence_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:d2_germline_alignment_aa ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr2_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:c_score ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:fwr3_end ],
+            owl:onProperty ak_schema:fwr4 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:d2_sequence_alignment ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:fwr3 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:quality ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_alignment_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:fwr3_aa ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:vj_in_frame ],
+            owl:onProperty ak_schema:j_germline_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cdr1 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:np1_aa ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr1 ],
+            owl:onProperty ak_schema:d_sequence_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_identity ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:v_support ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:j_germline_alignment_aa ],
+            owl:onProperty ak_schema:c_cigar ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:junction_aa ],
+            owl:onProperty ak_schema:d_sequence_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_support ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:n3_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:quality_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:j_sequence_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:v_sequence_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr4_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d_sequence_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:junction_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:np1_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:v_alignment_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:clone_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_cigar ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:junction_aa_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:rev_comp ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:np3_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_alignment_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr3_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:c_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence_alignment ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_alignment_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr3_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:p3d_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr4_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr2 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_sequence_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d2_germline_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:c_germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:p5j_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:j_call ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr3_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:vj_in_frame ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr3_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr1_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:np3_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:boolean ;
+            owl:onProperty ak_schema:complete_vdj ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:c_alignment_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:fwr4_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr3 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_sequence_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr1 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d2_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:np3_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr4_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr3_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:c_germline_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr4_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:c_germline_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_frame ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:consensus_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:junction_length ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_call ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr1_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_support ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:p3v_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:duplicate_count ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:n1_length ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_identity ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_score ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:j_identity ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr2_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:c_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr1_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr1 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_germline_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:j_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:v_call ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_frame ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:junction ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:consensus_count ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:stop_codon ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:c_sequence_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr2_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_support ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_call ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequence_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d2_support ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:productive ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:p3v_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_sequence_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequence_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:c_identity ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:np1_length ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d2_alignment_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_call ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_sequence_alignment ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_score ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_germline_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:j_alignment_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_alignment_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:c_alignment_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_score ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_frameshift ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_sequence_alignment ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:clone_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:fwr2_start ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr3_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:germline_alignment ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_alignment_end ],
+            owl:onProperty ak_schema:sample_processing_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_call ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr2_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:j_germline_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d2_germline_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_sequence_alignment_aa ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:fwr3_aa ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_alignment_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:d2_call ],
+            owl:onProperty ak_schema:fwr3_start ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_alignment_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:fwr2_aa ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_sequence_alignment ],
+            owl:onProperty ak_schema:fwr2_end ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr3_end ],
+            owl:onProperty ak_schema:n2_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:fwr2_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:np2_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:locus ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:n1_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:v_score ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:np3_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr4_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:data_processing_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_alignment_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:c_alignment_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:quality_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:c_sequence_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cdr2 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:stop_codon ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_germline_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:germline_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:c_score ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_germline_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:v_sequence_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_germline_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d_alignment_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:np2 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:p3d_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:boolean ;
+            owl:onProperty ak_schema:productive ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_sequence_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:v_identity ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:np2_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:junction ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d2_identity ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_score ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:j_germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_support ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:j_germline_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:n3_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_frame ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:junction_aa_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:v_sequence_alignment ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:fwr2 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:c_germline_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cdr1 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_cigar ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:p5j_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:p5d2_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:clone_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:fwr1 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_germline_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:np3_aa ],
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:d_support ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr1_start ],
+            owl:onProperty ak_schema:n3_length ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr1_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_identity ],
+            owl:onProperty ak_schema:j_sequence_alignment ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:junction_aa_length ],
+            owl:onProperty ak_schema:c_germline_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:n2_length ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:c_sequence_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:p3d_length ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:LocusEnum ;
             owl:onProperty ak_schema:locus ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_germline_alignment_aa ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d2_germline_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:np3_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:j_germline_alignment ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_identity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_germline_alignment ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:clone_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_alignment_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:n2_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:d_score ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:junction ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr2 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:np2 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr1 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:locus ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:stop_codon ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:rev_comp ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:d_germline_alignment ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:v_germline_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_alignment_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr1_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_alignment_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_alignment_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_support ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_frameshift ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:v_identity ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:c_germline_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_sequence_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_germline_alignment ],
+            owl:onProperty ak_schema:cell_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:np2_length ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr4_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr2_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_score ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr3 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_germline_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr2 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:np1 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_sequence_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr2_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:vj_in_frame ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:np1_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr3_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_cigar ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_score ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:boolean ;
-            owl:onProperty ak_schema:v_frameshift ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_germline_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:v_alignment_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:fwr3_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:d2_score ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_sequence_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:j_germline_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:v_support ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d2_alignment_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:c_sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:np2_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:quality_alignment ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:p3d_length ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_germline_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:np3 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr3_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:n2_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:c_sequence_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_call ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:v_germline_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr2_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_score ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_call ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr2_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:p5d_length ],
+            owl:onProperty ak_schema:d_alignment_end ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:c_germline_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr4 ],
+            owl:onProperty ak_schema:fwr2_end ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:d_cigar ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:duplicate_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cdr2 ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_support ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_identity ],
+            owl:onProperty ak_schema:d2_support ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_cigar ],
+            owl:onProperty ak_schema:d2_sequence_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:fwr4_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:j_sequence_end ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:data_processing_id ],
+            owl:onProperty ak_schema:c_support ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:boolean ;
-            owl:onProperty ak_schema:stop_codon ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_call ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr1_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr2_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:umi_count ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_alignment_start ],
+            owl:onProperty ak_schema:v_alignment_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:germline_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:fwr4 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_alignment_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:p5d_length ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:complete_vdj ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:cdr3_start ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_score ],
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr1_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_identity ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:boolean ;
+            owl:onProperty ak_schema:j_frameshift ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_sequence_end ],
+            owl:onProperty ak_schema:v_frameshift ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:j_cigar ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr4_start ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:p3d_length ],
+            owl:onProperty ak_schema:d_germline_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_germline_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_alignment_start ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:fwr1_aa ],
+            owl:onProperty ak_schema:quality_alignment ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr1_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr1_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:c_support ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:p5d2_length ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr2 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_alignment_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_cigar ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr2 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:clone_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_sequence_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:np1 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:d_sequence_end ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_sequence_alignment_aa ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:np1_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:v_sequence_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:fwr4 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:consensus_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_sequence_start ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr3 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d_alignment_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr4_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_germline_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_sequence_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:d_call ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:d2_support ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:c_sequence_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr2_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:j_sequence_alignment_aa ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:germline_alignment_aa ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:data_processing_id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr1 ],
+            owl:onProperty ak_schema:d2_sequence_alignment ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_alignment_start ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:d_sequence_alignment_aa ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:n1_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_sequence_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr1_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:fwr3 ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:np3 ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_score ],
+            owl:onProperty ak_schema:cdr1_end ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cdr1_aa ],
+            owl:onProperty ak_schema:fwr1_aa ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_cigar ],
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:fwr2_end ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_identity ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:v_sequence_alignment_aa ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_germline_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:p5j_length ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr2_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_germline_alignment ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:v_alignment_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:fwr1_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_sequence_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr3_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d_sequence_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:v_germline_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:complete_vdj ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:locus ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr1_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:v_sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ak_schema:float ;
             owl:onProperty ak_schema:d_identity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:p5d2_length ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:productive ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:c_germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:quality_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr2_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:junction ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:p5d_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:d2_cigar ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_sequence_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_alignment_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr2 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr4_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:fwr4_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_alignment_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_score ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:np2_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_cigar ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_cigar ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:d2_germline_alignment ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:fwr1_end ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:c_cigar ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:j_sequence_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:c_alignment_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:clone_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:c_identity ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_germline_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:data_processing_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_frame ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:data_processing_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:j_call ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:n1_length ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:junction ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d_germline_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cdr3 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_germline_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:n3_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:v_cigar ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr1_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:j_sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_frame ],
+            owl:onProperty ak_schema:d2_germline_alignment_aa ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:boolean ;
-            owl:onProperty ak_schema:productive ],
+            owl:onProperty ak_schema:rev_comp ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:p5j_length ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d2_germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_germline_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr3_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sample_processing_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d2_germline_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr1_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:np2_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d_alignment_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_alignment_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:np2 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:fwr4_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_alignment_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d2_alignment_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_sequence_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:boolean ;
+            owl:onProperty ak_schema:vj_in_frame ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:np1_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_alignment_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:p3d2_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_alignment_start ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:junction_aa_length ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr3_end ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_germline_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_sequence_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:np2 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_cigar ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d_germline_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d2_germline_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_sequence_start ],
+            owl:onProperty ak_schema:cdr1_end ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:quality ],
+            owl:onProperty ak_schema:fwr2_aa ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr3_aa ],
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d_frame ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:d_identity ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:d2_cigar ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:fwr1_start ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_sequence_end ],
+            owl:onProperty ak_schema:v_germline_start ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:cdr1_aa ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_sequence_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:np2_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:junction_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:np3 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr1_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:np1_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d2_germline_start ],
+            owl:onProperty ak_schema:d_support ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_cigar ],
+            owl:onProperty ak_schema:cdr2_end ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_score ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:fwr4_start ],
+            owl:onProperty ak_schema:d2_germline_end ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:n1_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:umi_count ],
+            owl:onProperty ak_schema:cdr3_aa ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_germline_start ],
+            owl:onProperty ak_schema:c_score ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_germline_end ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:d_germline_alignment_aa ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:complete_vdj ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_support ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr1_end ],
+            owl:onProperty ak_schema:j_sequence_alignment ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:d2_sequence_alignment ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:junction_aa_length ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:quality ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_germline_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_sequence_alignment ],
+            owl:onProperty ak_schema:j_sequence_start ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:p5d2_length ],
+            owl:onProperty ak_schema:j_alignment_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr2_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:p3v_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d2_frame ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_germline_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d_sequence_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:c_call ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:p3d2_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:boolean ;
+            owl:onProperty ak_schema:stop_codon ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr2_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:j_support ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:sequence_id ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr1_start ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:j_germline_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:fwr2 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_sequence_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_cigar ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:j_identity ],
+            owl:onProperty ak_schema:v_germline_start ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:n2_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:consensus_count ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:germline_alignment_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr3_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:junction_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
             owl:onProperty ak_schema:d_support ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_alignment_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:np1_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_alignment_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:d2_sequence_start ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:d2_sequence_alignment_aa ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:p3d2_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:j_alignment_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:d2_identity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr3_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:fwr2_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_sequence_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_sequence_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:quality_alignment ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_germline_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_germline_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_germline_start ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:boolean ;
-            owl:onProperty ak_schema:vj_in_frame ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_germline_alignment ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_identity ],
+            owl:onProperty ak_schema:v_frameshift ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_sequence_end ],
+            owl:onProperty ak_schema:d2_call ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr2_aa ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:germline_alignment ],
+            owl:onProperty ak_schema:c_sequence_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:np1 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d2_cigar ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:quality ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_call ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:c_call ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:fwr4_aa ],
+            owl:onProperty ak_schema:v_cigar ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:boolean ;
-            owl:onProperty ak_schema:rev_comp ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d2_alignment_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr4_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:np2_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sample_processing_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_frameshift ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_germline_alignment ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:fwr2 ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:fwr2_end ],
+            owl:onProperty ak_schema:fwr3_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:locus ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:np3 ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:v_germline_alignment_aa ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sample_processing_id ],
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:n2_length ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:junction_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_call ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d2_sequence_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_identity ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr3_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:j_cigar ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_identity ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:fwr3_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d2_frame ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_frameshift ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr3_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:np2_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_alignment_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:j_score ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d2_score ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:p3d2_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:fwr3_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:c_alignment_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_germline_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:d_score ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_cigar ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:np1_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d2_sequence_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:quality ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:n1_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d2_alignment_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:quality ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_cigar ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_score ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_sequence_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:fwr3 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:np3_length ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_germline_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:d_call ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_frameshift ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:d2_identity ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d2_alignment_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:junction_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:junction_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:np2 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:p5d_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:p5d2_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr3 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:productive ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_sequence_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_germline_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:umi_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:v_germline_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequence_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cdr3 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_identity ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr3 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_cigar ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:d2_score ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:d_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr1_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:c_identity ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cdr2_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:cell_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:duplicate_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:np1_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:junction_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:d2_support ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr2_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_sequence_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:d_sequence_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:d2_call ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:c_sequence_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:v_sequence_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:consensus_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cdr3_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_score ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_score ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr1 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:np1 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_sequence_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:c_germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:umi_count ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_germline_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_germline_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:p5d2_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:junction ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:c_score ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:c_sequence_start ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d2_sequence_end ],
+            owl:onProperty ak_schema:d_sequence_alignment_aa ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:boolean ;
-            owl:onProperty ak_schema:complete_vdj ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_sequence_alignment ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_sequence_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:repertoire_id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_germline_start ],
+            owl:onProperty ak_schema:sequence_aa ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cdr2_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:productive ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:p3v_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_support ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_support ],
+            owl:onProperty ak_schema:d_cigar ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d2_sequence_end ],
+            owl:onProperty ak_schema:fwr1_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:c_sequence_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr2_start ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr3 ],
+            owl:onProperty ak_schema:d_sequence_start ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:np2 ],
+            owl:onProperty ak_schema:complete_vdj ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:fwr1 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_cigar ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:c_sequence_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:d_germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d2_germline_alignment_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:np3 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:vj_in_frame ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr1 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr1_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:duplicate_count ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_germline_alignment ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:p5d_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_call ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_germline_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:np2_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:j_sequence_alignment ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_sequence_alignment ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_identity ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d2_sequence_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence_alignment ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:v_alignment_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:p5j_length ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_alignment_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_cigar ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:data_processing_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:np3_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sample_processing_id ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -2451,11 +2451,11 @@ ak_schema:Receptor a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Receptor" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:receptor_type ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:receptor_hash ],
+            owl:onProperty ak_schema:receptor_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:receptor_ref ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:receptor_id ],
@@ -2464,55 +2464,58 @@ ak_schema:Receptor a owl:Class,
             owl:onProperty ak_schema:receptor_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:receptor_hash ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:receptor_variable_domain_2_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:receptor_variable_domain_1_aa ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:receptor_variable_domain_1_locus ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:receptor_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:receptor_variable_domain_2_locus ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:receptor_variable_domain_2_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:ReceptorTypeEnum ;
-            owl:onProperty ak_schema:receptor_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:ReceptorVariableDomain2LocusEnum ;
-            owl:onProperty ak_schema:receptor_variable_domain_2_locus ],
+            owl:onProperty ak_schema:receptor_variable_domain_1_aa ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:receptor_ref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:ReceptorVariableDomain1LocusEnum ;
-            owl:onProperty ak_schema:receptor_variable_domain_1_locus ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:receptor_variable_domain_2_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:receptor_variable_domain_1_locus ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:receptor_variable_domain_1_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:receptor_hash ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:receptor_variable_domain_1_aa ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:ReceptorReactivity ;
             owl:onProperty ak_schema:reactivity_measurements ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:receptor_ref ],
+            owl:onProperty ak_schema:receptor_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:ReceptorTypeEnum ;
+            owl:onProperty ak_schema:receptor_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:receptor_variable_domain_1_locus ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:receptor_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:receptor_variable_domain_2_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:receptor_hash ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:receptor_variable_domain_1_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:ReceptorVariableDomain1LocusEnum ;
+            owl:onProperty ak_schema:receptor_variable_domain_1_locus ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:receptor_hash ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:reactivity_measurements ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:receptor_variable_domain_1_locus ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:receptor_variable_domain_2_locus ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:receptor_variable_domain_2_locus ],
@@ -2520,11 +2523,8 @@ ak_schema:Receptor a owl:Class,
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:receptor_variable_domain_2_aa ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:reactivity_measurements ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:receptor_id ],
+            owl:allValuesFrom ak_schema:ReceptorVariableDomain2LocusEnum ;
+            owl:onProperty ak_schema:receptor_variable_domain_2_locus ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -2532,62 +2532,62 @@ ak_schema:Repertoire a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Repertoire" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:study ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:repertoire_name ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:data_processing ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Subject ;
+            owl:onProperty ak_schema:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:repertoire_description ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:repertoire_name ],
+            owl:onProperty ak_schema:repertoire_description ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:repertoire_description ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:sample ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Study ;
+            owl:onProperty ak_schema:study ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:repertoire_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:SampleProcessing ;
+            owl:onProperty ak_schema:sample ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:study ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:DataProcessing ;
             owl:onProperty ak_schema:data_processing ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:data_processing ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:repertoire_name ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:repertoire_description ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:study ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Subject ;
-            owl:onProperty ak_schema:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Study ;
-            owl:onProperty ak_schema:study ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:repertoire_description ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:study ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SampleProcessing ;
-            owl:onProperty ak_schema:sample ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -2595,19 +2595,31 @@ ak_schema:RepertoireGroup a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "RepertoireGroup" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:repertoire_group_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:repertoire_group_description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:repertoires ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:repertoire_group_name ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:repertoire_group_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:repertoire_group_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:repertoire_group_description ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:repertoire_group_id ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:repertoire_group_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:repertoire_group_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:repertoire_group_description ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:RepertoireGroupDetail ;
@@ -2615,18 +2627,6 @@ ak_schema:RepertoireGroup a owl:Class,
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:repertoire_group_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:repertoire_group_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:repertoires ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:repertoire_group_description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:repertoire_group_name ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -2634,86 +2634,86 @@ ak_schema:Sample a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Sample" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:collection_time_point_relative ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sample_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:disease_state_sample ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:collection_time_point_reference ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:sample_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:disease_state_sample ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:disease_state_sample ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:collection_time_point_relative ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:CollectionTimePointRelativeUnitOntology ;
-            owl:onProperty ak_schema:collection_time_point_relative_unit ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:tissue ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:collection_time_point_reference ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:biomaterial_provider ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sample_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:biomaterial_provider ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:collection_time_point_relative_unit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sample_id ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sample_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:sample_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:TissueOntology ;
             owl:onProperty ak_schema:tissue ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:biomaterial_provider ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ak_schema:CollectionTimePointRelativeUnitOntology ;
             owl:onProperty ak_schema:collection_time_point_relative_unit ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sample_type ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:collection_time_point_relative ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:anatomic_site ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:collection_time_point_reference ],
+            owl:onProperty ak_schema:disease_state_sample ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:anatomic_site ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:collection_time_point_relative_unit ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sample_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:collection_time_point_reference ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:collection_time_point_relative ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:disease_state_sample ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:collection_time_point_reference ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:disease_state_sample ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:anatomic_site ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:collection_time_point_relative ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:tissue ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sample_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sample_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:anatomic_site ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:biomaterial_provider ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:collection_time_point_relative ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:collection_time_point_reference ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:collection_time_point_relative_unit ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -2721,39 +2721,53 @@ ak_schema:Tree a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Tree" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:clone_id ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:newick ],
+            owl:onProperty ak_schema:clone_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:clone_id ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:nodes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:newick ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:tree_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:newick ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Node ;
             owl:onProperty ak_schema:nodes ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:newick ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:tree_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:nodes ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:tree_id ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:clone_id ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:newick ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:clone_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:tree_id ],
         ak_schema:AIRRStandards ;
+    skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
+
+ak_schema:exclusion_criteria a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "exclusion_criteria" ;
+    rdfs:range ak_schema:string ;
+    skos:definition "Participants are excluded from an investigation if they meet this criteria" ;
+    skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
+
+ak_schema:inclusion_criteria a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "inclusion_criteria" ;
+    rdfs:range ak_schema:string ;
+    skos:definition "Participants in an investigation must meet this criteria" ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
 ak_schema:isotype a owl:ObjectProperty,
@@ -2767,31 +2781,31 @@ ak_schema:BCellReceptor a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "BCellReceptor" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:IGK_chain ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:IGH_chain ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Chain ;
+            owl:onProperty ak_schema:IGH_chain ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Chain ;
             owl:onProperty ak_schema:IGL_chain ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Chain ;
+            owl:onProperty ak_schema:IGK_chain ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:IGH_chain ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:IGL_chain ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:IGK_chain ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Chain ;
-            owl:onProperty ak_schema:IGH_chain ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Chain ;
-            owl:onProperty ak_schema:IGK_chain ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:IGH_chain ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:IGH_chain ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:IGK_chain ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:IGL_chain ],
         ak_schema:AKObject ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -2800,13 +2814,13 @@ ak_schema:ForeignObject a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ForeignObject" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:source_uri ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty ak_schema:source_uri ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:uriorcurie ;
-            owl:onProperty ak_schema:source_uri ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:source_uri ] ;
     skos:definition "An object held outside of the AK." ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -2815,50 +2829,50 @@ ak_schema:ImmuneExposure a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ImmuneExposure" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:LifeEvent ;
-            owl:onProperty ak_schema:life_event ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:disease ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:disease_stage ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:DiseaseOntology ;
             owl:onProperty ak_schema:disease ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:disease ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:disease_severity ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:exposure_material ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:life_event ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:disease_severity ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:disease ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:LifeEvent ;
+            owl:onProperty ak_schema:life_event ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:disease_stage ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:life_event ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:exposure_material ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:disease ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:ExposureMaterialOntology ;
             owl:onProperty ak_schema:exposure_material ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:exposure_material ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:disease_severity ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:disease_stage ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:disease_stage ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:disease_severity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:life_event ],
+            owl:onProperty ak_schema:disease_stage ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:life_event ],
+            owl:onProperty ak_schema:disease_stage ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:disease_severity ],
         ak_schema:NamedThing ;
     skos:definition "An event involving the immune system of a study participant." ;
     skos:exactMatch BFO:0000015 ;
@@ -2868,38 +2882,23 @@ ak_schema:NucleicAcidProcessing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "NucleicAcidProcessing" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:TemplateAmountUnitOntology ;
-            owl:onProperty ak_schema:template_amount_unit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:library_generation_method ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:template_amount ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:complete_sequences ],
+            owl:onProperty ak_schema:library_generation_protocol ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:template_quality ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:template_class ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:library_generation_kit_version ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:template_amount_unit ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:template_class ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:library_generation_protocol ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:physical_linkage ],
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:template_amount ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:library_generation_protocol ],
+            owl:onProperty ak_schema:template_amount ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:LibraryGenerationMethodEnum ;
             owl:onProperty ak_schema:library_generation_method ],
@@ -2907,23 +2906,20 @@ ak_schema:NucleicAcidProcessing a owl:Class,
             owl:allValuesFrom ak_schema:PhysicalLinkageEnum ;
             owl:onProperty ak_schema:physical_linkage ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:CompleteSequencesEnum ;
-            owl:onProperty ak_schema:complete_sequences ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:physical_linkage ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:template_class ],
+            owl:onProperty ak_schema:template_amount_unit ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:template_quality ],
+            owl:onProperty ak_schema:library_generation_kit_version ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:pcr_target ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:library_generation_method ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:complete_sequences ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:template_amount ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:template_quality ],
@@ -2934,26 +2930,44 @@ ak_schema:NucleicAcidProcessing a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:library_generation_kit_version ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:PCRTarget ;
-            owl:onProperty ak_schema:pcr_target ],
+            owl:allValuesFrom ak_schema:TemplateAmountUnitOntology ;
+            owl:onProperty ak_schema:template_amount_unit ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:library_generation_kit_version ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:pcr_target ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:TemplateClassEnum ;
             owl:onProperty ak_schema:template_class ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:library_generation_protocol ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:template_quality ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:CompleteSequencesEnum ;
             owl:onProperty ak_schema:complete_sequences ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:template_amount ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:physical_linkage ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:template_amount ],
+            owl:onProperty ak_schema:template_class ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:library_generation_method ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:PCRTarget ;
+            owl:onProperty ak_schema:pcr_target ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:complete_sequences ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:library_generation_protocol ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:physical_linkage ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -2968,68 +2982,68 @@ ak_schema:SequencingRun a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SequencingRun" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequencing_facility ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequencing_facility ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SequencingData ;
-            owl:onProperty ak_schema:sequencing_files ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:total_reads_passing_qc_filter ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequencing_facility ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequencing_files ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequencing_platform ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequencing_run_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:sequencing_kit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:total_reads_passing_qc_filter ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:total_reads_passing_qc_filter ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequencing_kit ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequencing_files ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:total_reads_passing_qc_filter ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequencing_run_date ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequencing_run_date ],
+            owl:onProperty ak_schema:sequencing_facility ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:sequencing_run_id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:sequencing_platform ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:SequencingData ;
+            owl:onProperty ak_schema:sequencing_files ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:datetime ;
             owl:onProperty ak_schema:sequencing_run_date ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequencing_run_date ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:total_reads_passing_qc_filter ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequencing_files ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:sequencing_platform ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:sequencing_run_id ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequencing_kit ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequencing_files ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequencing_run_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequencing_facility ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:sequencing_kit ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequencing_platform ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequencing_facility ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequencing_run_date ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -3040,17 +3054,17 @@ ak_schema:SimilarityCalculation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:chain_domain ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:chain_domain ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:chain_codomain ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Chain ;
             owl:onProperty ak_schema:chain_domain ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:chain_codomain ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:chain_codomain ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:chain_domain ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Chain ;
             owl:onProperty ak_schema:chain_codomain ],
@@ -3062,13 +3076,13 @@ ak_schema:SpecimenCollection a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SpecimenCollection" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:specimen ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:specimen ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Specimen ;
-            owl:onProperty ak_schema:specimen ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:specimen ],
         ak_schema:PlannedProcess ;
     skos:exactMatch OBI:0000659 ;
@@ -3360,443 +3374,443 @@ ak_schema:AlleleDescription a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "AlleleDescription" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_rs_3_prime_start ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:leader_1_end ],
+            owl:onProperty ak_schema:leader_2_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:status ],
+            owl:onProperty ak_schema:j_rs_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:j_rs_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:leader_2_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:release_version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:subgroup_designation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:InferenceTypeEnum ;
+            owl:onProperty ak_schema:inference_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:species_subgroup ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:leader_2_end ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:functional ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:allele_similarity_cluster_designation ],
+            owl:onProperty ak_schema:j_donor_splice ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d_rs_3_prime_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:leader_1_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_gene_delineations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:leader_2_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:v_rs_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:allele_description_id ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:boolean ;
             owl:onProperty ak_schema:functional ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:j_rs_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_rs_5_prime_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:leader_2_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SequenceDelineationV ;
-            owl:onProperty ak_schema:v_gene_delineations ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:allele_designation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:inference_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:gene_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:utr_5_prime_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_rs_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:chromosome ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:v_rs_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:LocusEnum ;
-            owl:onProperty ak_schema:locus ],
+            owl:onProperty ak_schema:allele_similarity_cluster_member_id ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:StatusEnum ;
             owl:onProperty ak_schema:status ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:curation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:coding_sequence ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:allele_description_ref ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:release_date ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_rs_3_prime_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:unrearranged_support ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_rs_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:allele_description_ref ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_codon_frame ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:chromosome ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_gene_delineations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_cdr3_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:paralogs ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d_rs_3_prime_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d_rs_3_prime_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:leader_2_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:functional ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:release_version ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:allele_designation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:maintainer ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:gene_designation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_rs_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:species_subgroup ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:allele_similarity_cluster_designation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:label ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_donor_splice ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:maintainer ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_rs_5_prime_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:utr_5_prime_end ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:species_subgroup_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:leader_2_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:allele_similarity_cluster_member_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:lab_address ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:acknowledgements ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_rs_5_prime_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:utr_5_prime_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_donor_splice ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:JCodonFrameEnum ;
-            owl:onProperty ak_schema:j_codon_frame ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:lab_address ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:subgroup_designation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:curation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:datetime ;
-            owl:onProperty ak_schema:release_date ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_rs_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:leader_1_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:release_version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:release_date ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:leader_1_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:allele_similarity_cluster_member_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:aliases ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:species ],
+            owl:onProperty ak_schema:allele_description_ref ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:CurationalTagsEnum ;
             owl:onProperty ak_schema:curational_tags ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:utr_5_prime_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_rs_5_prime_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:j_cdr3_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_rs_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:utr_5_prime_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:gene_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:rearranged_support ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_cdr3_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:chromosome ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d_rs_5_prime_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_rs_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_rs_3_prime_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SequenceTypeEnum ;
-            owl:onProperty ak_schema:sequence_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Acknowledgement ;
-            owl:onProperty ak_schema:acknowledgements ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:UnrearrangedSequence ;
-            owl:onProperty ak_schema:unrearranged_support ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:RearrangedSequence ;
-            owl:onProperty ak_schema:rearranged_support ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:subgroup_designation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:coding_sequence ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:release_description ],
+            owl:onProperty ak_schema:species_subgroup ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:SpeciesOntology ;
             owl:onProperty ak_schema:species ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:status ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:gene_start ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:j_rs_start ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_donor_splice ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:species_subgroup_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:allele_designation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:JCodonFrameEnum ;
+            owl:onProperty ak_schema:j_codon_frame ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:j_codon_frame ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:v_rs_end ],
+            owl:onProperty ak_schema:label ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:maintainer ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:paralogs ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:leader_1_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:allele_similarity_cluster_designation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:utr_5_prime_start ],
+            owl:onProperty ak_schema:gene_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:lab_address ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:gene_designation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:InferenceTypeEnum ;
-            owl:onProperty ak_schema:inference_type ],
+            owl:onProperty ak_schema:allele_designation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_codon_frame ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:gene_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:locus ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:paralogs ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:coding_sequence ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:curation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_rs_3_prime_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d_rs_5_prime_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d_rs_3_prime_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_cdr3_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_rs_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_cdr3_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:UnrearrangedSequence ;
+            owl:onProperty ak_schema:unrearranged_support ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:species_subgroup_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:leader_1_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_rs_5_prime_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:unrearranged_support ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:gene_designation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:d_rs_5_prime_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_rs_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:utr_5_prime_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:maintainer ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:SequenceDelineationV ;
+            owl:onProperty ak_schema:v_gene_delineations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:release_version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:leader_1_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:allele_description_ref ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:leader_1_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_rs_5_prime_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:allele_description_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:allele_similarity_cluster_member_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_rs_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:RearrangedSequence ;
+            owl:onProperty ak_schema:rearranged_support ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:release_description ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:j_cdr3_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_rs_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:utr_5_prime_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:v_rs_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:paralogs ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:allele_similarity_cluster_designation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:allele_similarity_cluster_member_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:release_description ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:lab_address ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:species ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:aliases ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:leader_1_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:j_donor_splice ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:aliases ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:gene_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:LocusEnum ;
+            owl:onProperty ak_schema:locus ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:status ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:gene_designation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:allele_description_ref ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:SpeciesSubgroupTypeEnum ;
             owl:onProperty ak_schema:species_subgroup_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:leader_2_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:gene_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:allele_designation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:release_version ],
+            owl:onProperty ak_schema:utr_5_prime_start ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:species_subgroup ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:allele_similarity_cluster_member_id ],
+            owl:onProperty ak_schema:coding_sequence ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:release_description ],
+            owl:onProperty ak_schema:d_rs_3_prime_start ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:j_donor_splice ],
+            owl:allValuesFrom ak_schema:datetime ;
+            owl:onProperty ak_schema:release_date ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:curation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:allele_description_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:inference_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:functional ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:SequenceTypeEnum ;
+            owl:onProperty ak_schema:sequence_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:label ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:label ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:gene_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:v_rs_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:release_date ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:utr_5_prime_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Acknowledgement ;
+            owl:onProperty ak_schema:acknowledgements ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:rearranged_support ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:chromosome ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:release_version ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:status ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:species ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_rs_3_prime_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:v_rs_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:locus ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:curational_tags ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:coding_sequence ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:label ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:gene_start ],
+            owl:onProperty ak_schema:utr_5_prime_end ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:allele_description_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:v_rs_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_rs_3_prime_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:allele_description_id ],
+            owl:onProperty ak_schema:gene_designation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:inference_type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:leader_2_start ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:allele_description_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:allele_designation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:functional ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_rs_3_prime_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:label ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:gene_designation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:subgroup_designation ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:allele_description_ref ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:gene_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:d_rs_5_prime_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:leader_1_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:leader_1_start ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:gene_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:species_subgroup ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:species_subgroup_type ],
+            owl:onProperty ak_schema:d_rs_5_prime_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:release_description ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence ],
+            owl:onProperty ak_schema:chromosome ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:locus ],
+            owl:onProperty ak_schema:allele_similarity_cluster_designation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:subgroup_designation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:leader_2_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:leader_2_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:maintainer ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:species_subgroup ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:leader_1_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:maintainer ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:curational_tags ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:chromosome ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:release_date ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:j_rs_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:gene_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:curation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:allele_similarity_cluster_designation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:v_rs_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:acknowledgements ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:lab_address ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:coding_sequence ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:d_rs_5_prime_start ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -3918,110 +3932,110 @@ ak_schema:DataProcessing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataProcessing" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:collapsing_method ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:germline_database ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:primer_match_cutoffs ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:analysis_provenance_id ],
+            owl:onProperty ak_schema:data_processing_files ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:primary_annotation ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:boolean ;
             owl:onProperty ak_schema:primary_annotation ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:germline_database ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:quality_thresholds ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:germline_database ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:data_processing_protocols ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:quality_thresholds ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:quality_thresholds ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:germline_set_ref ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:paired_reads_assembly ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:analysis_provenance_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:data_processing_protocols ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:analysis_provenance_id ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:primary_annotation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:germline_database ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:paired_reads_assembly ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:software_versions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:primer_match_cutoffs ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:data_processing_protocols ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:data_processing_files ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:primer_match_cutoffs ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:software_versions ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:germline_database ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:data_processing_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:quality_thresholds ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:primer_match_cutoffs ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:quality_thresholds ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:data_processing_id ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:collapsing_method ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:software_versions ],
+            owl:onProperty ak_schema:analysis_provenance_id ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:collapsing_method ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:paired_reads_assembly ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:data_processing_files ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:paired_reads_assembly ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:germline_database ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:primer_match_cutoffs ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:data_processing_protocols ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:germline_set_ref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:data_processing_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:primary_annotation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:germline_set_ref ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:collapsing_method ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:paired_reads_assembly ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:data_processing_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:collapsing_method ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:data_processing_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:germline_set_ref ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:analysis_provenance_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:software_versions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:data_processing_protocols ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:primer_match_cutoffs ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:analysis_provenance_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:collapsing_method ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:software_versions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:software_versions ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -4029,20 +4043,17 @@ ak_schema:DeletedGene a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DeletedGene" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:label ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:phasing ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:label ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:phasing ],
+            owl:onProperty ak_schema:germline_set_ref ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:label ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:germline_set_ref ],
+            owl:onProperty ak_schema:phasing ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:germline_set_ref ],
@@ -4051,10 +4062,13 @@ ak_schema:DeletedGene a owl:Class,
             owl:onProperty ak_schema:phasing ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:germline_set_ref ],
+            owl:onProperty ak_schema:label ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:phasing ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:label ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:germline_set_ref ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -4073,76 +4087,76 @@ ak_schema:Diagnosis a owl:Class,
     rdfs:label "Diagnosis" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:immunogen ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:disease_length ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:disease_stage ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:medical_history ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:immunogen ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:prior_therapies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:prior_therapies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:medical_history ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:disease_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:prior_therapies ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:disease_diagnosis ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:DiseaseDiagnosisOntology ;
             owl:onProperty ak_schema:disease_diagnosis ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:disease_length ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:study_group_description ],
+            owl:onProperty ak_schema:disease_stage ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:medical_history ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:disease_length ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:intervention ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:disease_stage ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:study_group_description ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:intervention ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:prior_therapies ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:disease_stage ],
+            owl:onProperty ak_schema:intervention ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:study_group_description ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:disease_stage ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:immunogen ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:disease_diagnosis ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:disease_diagnosis ],
+            owl:onProperty ak_schema:study_group_description ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:prior_therapies ],
+            owl:onProperty ak_schema:intervention ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:immunogen ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:disease_stage ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:disease_length ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:intervention ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:intervention ],
+            owl:onProperty ak_schema:immunogen ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:disease_diagnosis ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -4157,31 +4171,31 @@ ak_schema:DocumentedAllele a owl:Class,
     rdfs:label "DocumentedAllele" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:germline_set_ref ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:phasing ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:phasing ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:label ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:phasing ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:germline_set_ref ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:germline_set_ref ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:label ],
+            owl:onProperty ak_schema:germline_set_ref ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:phasing ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:label ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:germline_set_ref ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:label ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:phasing ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -4320,50 +4334,50 @@ ak_schema:Genotype a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Genotype" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:DocumentedAllele ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:documented_alleles ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:UndocumentedAllele ;
-            owl:onProperty ak_schema:undocumented_alleles ],
+            owl:allValuesFrom ak_schema:LocusEnum ;
+            owl:onProperty ak_schema:locus ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:InferenceProcessEnum ;
-            owl:onProperty ak_schema:inference_process ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:documented_alleles ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:deleted_genes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:receptor_genotype_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:undocumented_alleles ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:inference_process ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:inference_process ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:DeletedGene ;
             owl:onProperty ak_schema:deleted_genes ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:LocusEnum ;
-            owl:onProperty ak_schema:locus ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:locus ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:deleted_genes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:inference_process ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:receptor_genotype_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:UndocumentedAllele ;
+            owl:onProperty ak_schema:undocumented_alleles ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:DocumentedAllele ;
+            owl:onProperty ak_schema:documented_alleles ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:locus ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:undocumented_alleles ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:receptor_genotype_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:receptor_genotype_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:inference_process ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -4374,9 +4388,6 @@ ak_schema:GenotypeSet a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:receptor_genotype_set_id ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:receptor_genotype_set_id ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:receptor_genotype_set_id ],
         [ a owl:Restriction ;
@@ -4385,6 +4396,9 @@ ak_schema:GenotypeSet a owl:Class,
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:genotype_class_list ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:receptor_genotype_set_id ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -4595,32 +4609,32 @@ ak_schema:MHCAllele a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MHCAllele" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:reference_set_ref ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:allele_designation ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:gene ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:reference_set_ref ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:allele_designation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:reference_set_ref ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:allele_designation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:gene ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:GeneOntology ;
             owl:onProperty ak_schema:gene ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:reference_set_ref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:allele_designation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:gene ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:allele_designation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:reference_set_ref ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:reference_set_ref ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -4628,37 +4642,37 @@ ak_schema:MHCGenotype a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MHCGenotype" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:mhc_class ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:mhc_genotype_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:mhc_genotype_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:mhc_alleles ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:mhc_class ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:mhc_genotype_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:mhc_genotyping_method ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:MhcClassEnum ;
+            owl:onProperty ak_schema:mhc_class ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:mhc_genotype_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:mhc_class ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:MHCAllele ;
             owl:onProperty ak_schema:mhc_alleles ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:mhc_genotype_id ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:mhc_genotype_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:mhc_class ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:mhc_alleles ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:mhc_genotyping_method ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:mhc_genotyping_method ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:mhc_genotyping_method ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -4670,17 +4684,17 @@ ak_schema:MHCGenotypeSet a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:mhc_genotype_set_id ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:mhc_genotype_set_id ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:mhc_genotype_set_id ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:MHCGenotype ;
+            owl:onProperty ak_schema:mhc_genotype_list ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:mhc_genotype_list ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:MHCGenotype ;
-            owl:onProperty ak_schema:mhc_genotype_list ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:mhc_genotype_set_id ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -4717,40 +4731,40 @@ ak_schema:Node a owl:Class,
     rdfs:label "Node" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:junction ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:sequence_id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:junction ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:junction_aa ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequence_alignment ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:sequence_alignment ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:sequence_alignment ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:junction ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:junction_aa ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:junction_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:junction_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequence_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:sequence_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:junction ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:junction_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_alignment ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_id ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -4824,13 +4838,16 @@ ak_schema:PeptidicEpitope a owl:Class,
     rdfs:label "PeptidicEpitope" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:source_protein ],
+            owl:onProperty ak_schema:sequence_aa ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:source_protein ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:source_protein ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence_aa ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:source_organism ],
@@ -4838,17 +4855,14 @@ ak_schema:PeptidicEpitope a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:source_organism ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_aa ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:sequence_aa ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:source_organism ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:source_protein ],
         ak_schema:Epitope ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -5089,95 +5103,95 @@ ak_schema:RearrangedSequence a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "RearrangedSequence" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:deposited_version ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:sequence_id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:repository_name ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:deposited_version ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:sequence_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:curation ],
+            owl:onProperty ak_schema:repository_name ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:repository_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:repository_ref ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:repository_ref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:curation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:derivation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:deposited_version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:deposited_version ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:observation_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:observation_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequence ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:sequence_start ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:observation_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:repository_name ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:DerivationEnum ;
             owl:onProperty ak_schema:derivation ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:curation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:curation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:sequence_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:curation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:derivation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:derivation ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:ObservationTypeEnum ;
             owl:onProperty ak_schema:observation_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:derivation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:sequence_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:repository_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:curation ],
+            owl:onProperty ak_schema:observation_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:sequence_end ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:repository_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:deposited_version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:repository_ref ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:deposited_version ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -5185,137 +5199,137 @@ ak_schema:ReceptorReactivity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ReceptorReactivity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:reactivity_unit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:peptide_end ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:antigen ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:antigen_source_species ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:ligand_type ],
+            owl:onProperty ak_schema:peptide_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:reactivity_readout ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:reactivity_method ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:mhc_class ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:peptide_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:mhc_allele_2 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:LigandTypeEnum ;
-            owl:onProperty ak_schema:ligand_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:reactivity_method ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:mhc_allele_1 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:mhc_gene_2 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:reactivity_unit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:mhc_allele_1 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:antigen_source_species ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:mhc_gene_1 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:MhcGene2Ontology ;
-            owl:onProperty ak_schema:mhc_gene_2 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:MhcGene1Ontology ;
-            owl:onProperty ak_schema:mhc_gene_1 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:ReactivityMethodEnum ;
-            owl:onProperty ak_schema:reactivity_method ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:ReactivityReadoutEnum ;
-            owl:onProperty ak_schema:reactivity_readout ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:ligand_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:peptide_start ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:reactivity_unit ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:mhc_gene_1 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:reactivity_value ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:AntigenSourceSpeciesOntology ;
-            owl:onProperty ak_schema:antigen_source_species ],
+            owl:onProperty ak_schema:antigen_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:MhcClassEnum ;
             owl:onProperty ak_schema:mhc_class ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:mhc_allele_1 ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:ligand_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:mhc_gene_2 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:peptide_start ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:reactivity_method ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:antigen ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:mhc_class ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:reactivity_method ],
+            owl:onProperty ak_schema:ligand_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:float ;
             owl:onProperty ak_schema:reactivity_value ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:peptide_end ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:AntigenOntology ;
             owl:onProperty ak_schema:antigen ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:mhc_gene_1 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:mhc_allele_2 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:mhc_allele_2 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:reactivity_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:mhc_allele_1 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:reactivity_unit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:peptide_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:MhcGene1Ontology ;
+            owl:onProperty ak_schema:mhc_gene_1 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:reactivity_readout ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:AntigenTypeEnum ;
             owl:onProperty ak_schema:antigen_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:AntigenSourceSpeciesOntology ;
+            owl:onProperty ak_schema:antigen_source_species ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:MhcGene2Ontology ;
+            owl:onProperty ak_schema:mhc_gene_2 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:LigandTypeEnum ;
+            owl:onProperty ak_schema:ligand_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:mhc_allele_2 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:mhc_gene_1 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:antigen ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:ReactivityMethodEnum ;
+            owl:onProperty ak_schema:reactivity_method ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:antigen ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:peptide_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:mhc_allele_1 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:mhc_class ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:reactivity_value ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:mhc_gene_2 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:ReactivityReadoutEnum ;
             owl:onProperty ak_schema:reactivity_readout ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:peptide_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:mhc_allele_2 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:antigen_source_species ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:mhc_allele_2 ],
+            owl:onProperty ak_schema:mhc_allele_1 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:reactivity_readout ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:antigen_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:peptide_start ],
+            owl:onProperty ak_schema:reactivity_unit ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:antigen_type ],
@@ -5379,29 +5393,29 @@ ak_schema:RepertoireGroupDetail a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:time_point ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:time_point ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:repertoire_id ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:TimePoint ;
             owl:onProperty ak_schema:time_point ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:repertoire_id ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:repertoire_description ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:repertoire_description ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:repertoire_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:time_point ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:repertoire_description ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:repertoire_description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:repertoire_id ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -5409,146 +5423,290 @@ ak_schema:SampleProcessing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SampleProcessing" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_subset ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:collection_time_point_reference ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequencing_run_date ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:library_generation_method ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:TemplateClassEnum ;
+            owl:onProperty ak_schema:template_class ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sample_processing_id ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:sample_processing_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:template_quality ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:biomaterial_provider ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequencing_kit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:tissue ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:anatomic_site ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cell_number ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:library_generation_protocol ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:template_amount_unit ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequencing_facility ],
+            owl:onProperty ak_schema:biomaterial_provider ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:collection_time_point_reference ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cells_per_reaction ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_quality ],
+            owl:onProperty ak_schema:sample_id ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:datetime ;
             owl:onProperty ak_schema:sequencing_run_date ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:single_cell ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequencing_run_id ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_subset ],
+            owl:onProperty ak_schema:template_class ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:physical_linkage ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:total_reads_passing_qc_filter ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:collection_time_point_relative ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:collection_time_point_relative_unit ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:total_reads_passing_qc_filter ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:cell_isolation ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequencing_files ],
+            owl:allValuesFrom ak_schema:PCRTarget ;
+            owl:onProperty ak_schema:pcr_target ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:tissue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:boolean ;
             owl:onProperty ak_schema:single_cell ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:boolean ;
+            owl:onProperty ak_schema:cell_storage ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequencing_facility ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:collection_time_point_relative_unit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:library_generation_protocol ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_phenotype ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_species ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:library_generation_protocol ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cells_per_reaction ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cell_number ],
+            owl:onProperty ak_schema:cell_quality ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_isolation ],
+            owl:onProperty ak_schema:disease_state_sample ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequencing_platform ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:library_generation_protocol ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:biomaterial_provider ],
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:template_amount ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:sequencing_facility ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_number ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:library_generation_method ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:CompleteSequencesEnum ;
-            owl:onProperty ak_schema:complete_sequences ],
+            owl:onProperty ak_schema:library_generation_protocol ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sample_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_subset ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:pcr_target ],
+            owl:onProperty ak_schema:single_cell ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:tissue_processing ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sample_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:template_quality ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:disease_state_sample ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_number ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequencing_run_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:biomaterial_provider ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:disease_state_sample ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:LibraryGenerationMethodEnum ;
+            owl:onProperty ak_schema:library_generation_method ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_quality ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:library_generation_kit_version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequencing_files ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:sequencing_platform ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:complete_sequences ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:tissue ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_storage ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:TissueOntology ;
+            owl:onProperty ak_schema:tissue ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:anatomic_site ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequencing_run_date ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_species ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequencing_kit ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_storage ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:cell_phenotype ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:CellSpeciesOntology ;
-            owl:onProperty ak_schema:cell_species ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequencing_platform ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:library_generation_protocol ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequencing_kit ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:library_generation_method ],
+            owl:onProperty ak_schema:sequencing_run_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:collection_time_point_relative ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sample_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cell_phenotype ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequencing_run_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_species ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sample_processing_id ],
+            owl:onProperty ak_schema:cell_processing_protocol ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:library_generation_kit_version ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:PhysicalLinkageEnum ;
             owl:onProperty ak_schema:physical_linkage ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sample_id ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:physical_linkage ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:template_amount ],
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cells_per_reaction ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_subset ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:anatomic_site ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:cells_per_reaction ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequencing_kit ],
+            owl:onProperty ak_schema:sequencing_files ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:total_reads_passing_qc_filter ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:boolean ;
+            owl:onProperty ak_schema:single_cell ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:SequencingData ;
+            owl:onProperty ak_schema:sequencing_files ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:template_class ],
+            owl:onProperty ak_schema:library_generation_kit_version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sample_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_processing_protocol ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:template_amount_unit ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:collection_time_point_relative ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:CellSubsetOntology ;
+            owl:onProperty ak_schema:cell_subset ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequencing_kit ],
+            owl:onProperty ak_schema:tissue_processing ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cell_quality ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:template_quality ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:library_generation_method ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequencing_platform ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:pcr_target ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:template_amount ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:template_amount ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sample_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:collection_time_point_reference ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cell_isolation ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:CollectionTimePointRelativeUnitOntology ;
             owl:onProperty ak_schema:collection_time_point_relative_unit ],
@@ -5556,197 +5714,53 @@ ak_schema:SampleProcessing a owl:Class,
             owl:allValuesFrom ak_schema:TemplateAmountUnitOntology ;
             owl:onProperty ak_schema:template_amount_unit ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:total_reads_passing_qc_filter ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequencing_platform ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:anatomic_site ],
+            owl:onProperty ak_schema:physical_linkage ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:biomaterial_provider ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ak_schema:CompleteSequencesEnum ;
             owl:onProperty ak_schema:complete_sequences ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:disease_state_sample ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:template_class ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_processing_protocol ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sample_processing_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequencing_files ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequencing_run_date ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sample_type ],
+            owl:allValuesFrom ak_schema:CellSpeciesOntology ;
+            owl:onProperty ak_schema:cell_species ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:anatomic_site ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:anatomic_site ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:complete_sequences ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:template_quality ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequencing_run_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:cell_phenotype ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:collection_time_point_relative_unit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_processing_protocol ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequencing_facility ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_isolation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:total_reads_passing_qc_filter ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequencing_kit ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:collection_time_point_relative ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_storage ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:template_amount ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:library_generation_kit_version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:template_amount_unit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sample_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:cell_number ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sample_processing_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:tissue_processing ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequencing_facility ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequencing_run_id ],
+            owl:onProperty ak_schema:cell_isolation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:library_generation_kit_version ],
+            owl:onProperty ak_schema:sample_type ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_species ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:complete_sequences ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:single_cell ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:collection_time_point_reference ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:library_generation_kit_version ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:biomaterial_provider ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:PCRTarget ;
-            owl:onProperty ak_schema:pcr_target ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cell_processing_protocol ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:template_quality ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequencing_run_date ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:collection_time_point_relative ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SequencingData ;
-            owl:onProperty ak_schema:sequencing_files ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:TemplateClassEnum ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:template_class ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sample_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:disease_state_sample ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_storage ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:tissue_processing ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cell_quality ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:tissue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:collection_time_point_reference ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:disease_state_sample ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:template_quality ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:CellSubsetOntology ;
-            owl:onProperty ak_schema:cell_subset ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:template_amount ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:collection_time_point_relative_unit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sample_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:TissueOntology ;
-            owl:onProperty ak_schema:tissue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cells_per_reaction ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:LibraryGenerationMethodEnum ;
-            owl:onProperty ak_schema:library_generation_method ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:physical_linkage ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:boolean ;
-            owl:onProperty ak_schema:cell_storage ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cell_quality ],
+            owl:onProperty ak_schema:cell_processing_protocol ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -5754,101 +5768,125 @@ ak_schema:SequenceDelineationV a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SequenceDelineationV" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:delineation_scheme ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr2_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:alignment_labels ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr1_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:aligned_sequence ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:fwr2_start ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:alignment_labels ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:unaligned_sequence ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr3_end ],
+            owl:onProperty ak_schema:unaligned_sequence ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:aligned_sequence ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr3_start ],
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr2_end ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:fwr1_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:fwr2_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr3_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:fwr3_start ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:cdr2_start ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr1_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr2_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:fwr2_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr1_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr1_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:fwr2_end ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:delineation_scheme ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:aligned_sequence ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr3_end ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr1_end ],
+            owl:onProperty ak_schema:alignment_labels ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequence_delineation_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr3_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr2_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr2_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr1_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence_delineation_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr2_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:aligned_sequence ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr1_start ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:fwr1_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr1_start ],
+            owl:onProperty ak_schema:fwr3_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr1_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr1_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr3_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:delineation_scheme ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:fwr2_start ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:fwr1_end ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr2_start ],
+            owl:onProperty ak_schema:cdr1_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr3_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr2_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:fwr3_start ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:unaligned_sequence ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:sequence_delineation_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:aligned_sequence ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:fwr3_end ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:fwr2_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:fwr1_start ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr3_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:delineation_scheme ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr1_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr2_start ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:unaligned_sequence ],
@@ -5856,43 +5894,19 @@ ak_schema:SequenceDelineationV a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:fwr3_start ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:alignment_labels ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:fwr2_end ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:unaligned_sequence ],
+            owl:onProperty ak_schema:fwr2_end ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:fwr1_start ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr1_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_delineation_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr3_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr2_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr3_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr1_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr2_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:fwr3_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr2_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_delineation_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:fwr1_end ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -6053,137 +6067,137 @@ ak_schema:Study a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Study" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:study_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:pub_ids ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:study_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:inclusion_exclusion_criteria ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:lab_address ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:inclusion_exclusion_criteria ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:StudyTypeOntology ;
-            owl:onProperty ak_schema:study_type ],
+            owl:onProperty ak_schema:study_contact ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:inclusion_exclusion_criteria ],
+            owl:onProperty ak_schema:submitted_by ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:datetime ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:submitted_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:lab_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:lab_address ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:adc_update_date ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:grants ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:study_contact ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:adc_publish_date ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:study_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:grants ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:study_contact ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:lab_address ],
+            owl:onProperty ak_schema:inclusion_exclusion_criteria ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:submitted_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:lab_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:lab_address ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:submitted_by ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:lab_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:submitted_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:datetime ;
-            owl:onProperty ak_schema:adc_publish_date ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:study_title ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:grants ],
+            owl:onProperty ak_schema:collected_by ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:adc_publish_date ],
+            owl:onProperty ak_schema:grants ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:collected_by ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:KeywordsStudyEnum ;
             owl:onProperty ak_schema:keywords_study ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:adc_update_date ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:study_contact ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:study_title ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:collected_by ],
+            owl:onProperty ak_schema:lab_address ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:study_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:study_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:study_description ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:study_description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:collected_by ],
+            owl:onProperty ak_schema:adc_publish_date ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:keywords_study ],
+            owl:onProperty ak_schema:study_description ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:pub_ids ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:pub_ids ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:study_title ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:study_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:StudyTypeOntology ;
+            owl:onProperty ak_schema:study_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:datetime ;
+            owl:onProperty ak_schema:adc_update_date ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:adc_publish_date ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:datetime ;
+            owl:onProperty ak_schema:adc_publish_date ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:inclusion_exclusion_criteria ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:inclusion_exclusion_criteria ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:lab_name ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:lab_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:submitted_by ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:collected_by ],
+            owl:onProperty ak_schema:study_contact ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:study_id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:pub_ids ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:keywords_study ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:lab_address ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:adc_update_date ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:study_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:study_title ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:grants ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:study_description ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:study_contact ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:adc_update_date ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:collected_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:study_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:pub_ids ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:grants ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -6191,146 +6205,146 @@ ak_schema:Subject a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Subject" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:ancestry_population ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:race ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:species ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:ethnicity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:ancestry_population ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SexEnum ;
-            owl:onProperty ak_schema:sex ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:genotype ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:genotype ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:linked_subjects ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:link_type ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:age_max ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:strain_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:ancestry_population ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:age_min ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sex ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:linked_subjects ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:diagnosis ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:ethnicity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:strain_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:ethnicity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:age_max ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:age_unit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:subject_id ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:boolean ;
             owl:onProperty ak_schema:synthetic ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:race ],
+            owl:onProperty ak_schema:sex ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sex ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:link_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:age_event ],
+            owl:onProperty ak_schema:age_min ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SpeciesOntology ;
+            owl:allValuesFrom ak_schema:float ;
+            owl:onProperty ak_schema:age_max ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:diagnosis ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:ethnicity ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:subject_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:ancestry_population ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:age_min ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:species ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SubjectGenotype ;
-            owl:onProperty ak_schema:genotype ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:race ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:strain_name ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:ethnicity ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:age_event ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:synthetic ],
+            owl:onProperty ak_schema:ancestry_population ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:linked_subjects ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:link_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:linked_subjects ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Diagnosis ;
             owl:onProperty ak_schema:diagnosis ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:species ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:AgeUnitOntology ;
+            owl:onProperty ak_schema:age_unit ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:SexEnum ;
             owl:onProperty ak_schema:sex ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:linked_subjects ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:link_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:genotype ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:age_unit ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:age_max ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:link_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:float ;
-            owl:onProperty ak_schema:age_min ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:link_type ],
+            owl:onProperty ak_schema:ancestry_population ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:age_unit ],
+            owl:onProperty ak_schema:linked_subjects ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:age_event ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:age_min ],
+            owl:onProperty ak_schema:ethnicity ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:species ],
+            owl:onProperty ak_schema:strain_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:age_event ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:genotype ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:synthetic ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:age_event ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:race ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:subject_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:AgeUnitOntology ;
-            owl:onProperty ak_schema:age_unit ],
+            owl:allValuesFrom ak_schema:SubjectGenotype ;
+            owl:onProperty ak_schema:genotype ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:subject_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:SpeciesOntology ;
+            owl:onProperty ak_schema:species ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:synthetic ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:strain_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:age_unit ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:subject_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:race ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:strain_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:age_max ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -6338,22 +6352,22 @@ ak_schema:SubjectGenotype a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SubjectGenotype" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:mhc_genotype_set ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:receptor_genotype_set ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:MHCGenotypeSet ;
+            owl:onProperty ak_schema:mhc_genotype_set ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:mhc_genotype_set ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:receptor_genotype_set ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:GenotypeSet ;
-            owl:onProperty ak_schema:receptor_genotype_set ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:mhc_genotype_set ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:mhc_genotype_set ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:receptor_genotype_set ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -6362,23 +6376,8 @@ ak_schema:TCellReceptorEpitopeBindingAssay a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "TCellReceptorEpitopeBindingAssay" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:value ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:unit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:unit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Epitope ;
-            owl:onProperty ak_schema:epitope ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:epitope ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:value ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:tcell_receptors ],
@@ -6386,14 +6385,29 @@ ak_schema:TCellReceptorEpitopeBindingAssay a owl:Class,
             owl:allValuesFrom ak_schema:TCellReceptor ;
             owl:onProperty ak_schema:tcell_receptors ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:unit ],
+            owl:allValuesFrom ak_schema:Epitope ;
+            owl:onProperty ak_schema:epitope ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:value ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:value ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:epitope ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:epitope ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:unit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:unit ],
         ak_schema:Assay ;
     skos:exactMatch OBI:1110037 ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -6412,32 +6426,32 @@ ak_schema:TimePoint a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "TimePoint" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:time_point_value ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:time_point_label ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:float ;
             owl:onProperty ak_schema:time_point_value ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:TimePointUnitOntology ;
-            owl:onProperty ak_schema:time_point_unit ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:time_point_label ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:time_point_value ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:time_point_unit ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:time_point_label ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:time_point_label ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:time_point_unit ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:time_point_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:time_point_label ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:TimePointUnitOntology ;
+            owl:onProperty ak_schema:time_point_unit ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -6448,32 +6462,32 @@ ak_schema:UndocumentedAllele a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "UndocumentedAllele" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:allele_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:allele_name ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:phasing ],
+            owl:onProperty ak_schema:allele_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:phasing ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:phasing ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:allele_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:phasing ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:allele_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:allele_name ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -6481,95 +6495,95 @@ ak_schema:UnrearrangedSequence a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "UnrearrangedSequence" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:gff_seqid ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:strand ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:gff_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:curation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:curation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:gff_seqid ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:gff_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:curation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:repository_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:gff_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:patch_no ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:repository_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:gff_seqid ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:patch_no ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence_id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:repository_ref ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:repository_ref ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:StrandEnum ;
             owl:onProperty ak_schema:strand ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:patch_no ],
+            owl:onProperty ak_schema:sequence ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:gff_start ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:curation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:gff_end ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:repository_name ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:gff_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:patch_no ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:repository_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:gff_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:gff_seqid ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:gff_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:sequence_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:repository_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:strand ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:repository_ref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:curation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:repository_ref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:repository_ref ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:strand ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:gff_seqid ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:gff_end ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:repository_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:curation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:patch_no ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:gff_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:gff_seqid ],
+            owl:onProperty ak_schema:sequence ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -6910,41 +6924,41 @@ ak_schema:Acknowledgement a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Acknowledgement" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:acknowledgement_id ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:acknowledgement_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:orcid_id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:institution_name ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:individual_full_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:individual_full_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:orcid_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:acknowledgement_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:institution_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:orcid_id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:individual_full_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:individual_full_name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:acknowledgement_id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:individual_full_name ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:orcid_id ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:institution_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:acknowledgement_id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:individual_full_name ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -6955,10 +6969,16 @@ ak_schema:AlphaBetaTCR a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "AlphaBetaTCR" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:TRB_chain ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Chain ;
             owl:onProperty ak_schema:TRB_chain ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:TRA_chain ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Chain ;
             owl:onProperty ak_schema:TRA_chain ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -6966,12 +6986,6 @@ ak_schema:AlphaBetaTCR a owl:Class,
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:TRA_chain ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Chain ;
-            owl:onProperty ak_schema:TRA_chain ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:TRB_chain ],
         ak_schema:TCellReceptor ;
     skos:exactMatch GO:0042105 ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -6980,50 +6994,50 @@ ak_schema:Assessment a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Assessment" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:unit ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:value ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:assessment_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:life_event ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:life_event ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:assessment_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:target_entity_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:value ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:unit ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:unit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:assessment_type ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:LifeEvent ;
             owl:onProperty ak_schema:life_event ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:unit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:life_event ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:unit ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:life_event ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:target_entity_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:unit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:assessment_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:target_entity_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:target_entity_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:assessment_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:value ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:value ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:assessment_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:value ],
         ak_schema:PlannedProcess ;
     skos:exactMatch OBI:0002441 ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -7035,62 +7049,62 @@ ak_schema:Conclusion a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Conclusion" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:data_location_value ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:experiment_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:data_location_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:data_location_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:result ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:data_location_value ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Investigation ;
+            owl:onProperty ak_schema:investigations ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:organism ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:result ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:experiment_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:data_location_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Dataset ;
+            owl:onProperty ak_schema:datasets ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:organism ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:investigations ],
+            owl:onProperty ak_schema:data_location_value ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:result ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:datasets ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:data_location_value ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:data_location_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:data_location_value ],
+            owl:onProperty ak_schema:data_location_type ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:investigations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:experiment_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:SpeciesOntology ;
             owl:onProperty ak_schema:organism ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:result ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Dataset ;
-            owl:onProperty ak_schema:datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Investigation ;
-            owl:onProperty ak_schema:investigations ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:result ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:experiment_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:datasets ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:organism ],
         ak_schema:NamedThing ;
     skos:exactMatch OBI:0001909 ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -7119,21 +7133,21 @@ ak_schema:GammaDeltaTCR a owl:Class,
     rdfs:label "GammaDeltaTCR" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:TRD_chain ],
+            owl:onProperty ak_schema:TRG_chain ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:TRD_chain ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Chain ;
             owl:onProperty ak_schema:TRG_chain ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:TRD_chain ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:TRG_chain ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Chain ;
             owl:onProperty ak_schema:TRD_chain ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Chain ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:TRG_chain ],
         ak_schema:TCellReceptor ;
     skos:exactMatch GO:0042106 ;
@@ -7164,32 +7178,32 @@ ak_schema:PCRTarget a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "PCRTarget" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:reverse_pcr_primer_target_location ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:forward_pcr_primer_target_location ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:reverse_pcr_primer_target_location ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:pcr_target_locus ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:forward_pcr_primer_target_location ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:PcrTargetLocusEnum ;
             owl:onProperty ak_schema:pcr_target_locus ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:forward_pcr_primer_target_location ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:forward_pcr_primer_target_location ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:reverse_pcr_primer_target_location ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:forward_pcr_primer_target_location ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:reverse_pcr_primer_target_location ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:pcr_target_locus ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:pcr_target_locus ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:reverse_pcr_primer_target_location ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -7197,23 +7211,44 @@ ak_schema:Reference a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Reference" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:pages ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:issue ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:month ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:journal ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Investigation ;
-            owl:onProperty ak_schema:investigations ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:title ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:title ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:year ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:issue ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:pages ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:pages ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:investigations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:journal ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:uriorcurie ;
+            owl:onProperty ak_schema:sources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:issue ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:authors ],
@@ -7221,20 +7256,11 @@ ak_schema:Reference a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:year ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:month ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Investigation ;
             owl:onProperty ak_schema:investigations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:journal ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:authors ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:journal ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( ak_schema:integer [ a rdfs:Datatype ;
@@ -7242,35 +7268,23 @@ ak_schema:Reference a owl:Class,
                                 owl:withRestrictions ( [ xsd:pattern "19\\d\\d|20\\d\\d" ] ) ] ) ] ;
             owl:onProperty ak_schema:year ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:uriorcurie ;
-            owl:onProperty ak_schema:sources ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:month ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:journal ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:title ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:year ],
+            owl:onProperty ak_schema:authors ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:pages ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:pages ],
+            owl:onProperty ak_schema:journal ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:month ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:issue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:title ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:issue ],
         ak_schema:ForeignObject ;
     skos:definition "A document about an investigation." ;
     skos:exactMatch IAO:0000310 ;
@@ -7280,95 +7294,95 @@ ak_schema:SequencingData a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SequencingData" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:file_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:paired_read_direction ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:index_filename ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:read_direction ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:paired_read_length ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:paired_read_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:filename ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:index_length ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:paired_filename ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:read_direction ],
+            owl:onProperty ak_schema:paired_read_direction ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:FileTypeEnum ;
-            owl:onProperty ak_schema:file_type ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequencing_data_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:read_length ],
+            owl:onProperty ak_schema:paired_filename ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:PairedReadDirectionEnum ;
-            owl:onProperty ak_schema:paired_read_direction ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:filename ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:ReadDirectionEnum ;
             owl:onProperty ak_schema:read_direction ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:paired_filename ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:read_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:FileTypeEnum ;
+            owl:onProperty ak_schema:file_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:index_length ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:read_direction ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:read_length ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:index_filename ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:filename ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequencing_data_id ],
+            owl:onProperty ak_schema:read_direction ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:index_filename ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:filename ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:index_length ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:read_length ],
+            owl:onProperty ak_schema:paired_read_length ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:index_filename ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:paired_read_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:PairedReadDirectionEnum ;
             owl:onProperty ak_schema:paired_read_direction ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequencing_data_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequencing_data_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:paired_filename ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:index_filename ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:file_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:paired_read_direction ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:file_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:index_filename ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:read_length ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequencing_data_id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:index_length ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:paired_read_length ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:filename ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:index_length ],
+            owl:onProperty ak_schema:sequencing_data_id ],
         ak_schema:AIRRStandards ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -7376,10 +7390,10 @@ ak_schema:StudyEvent a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "StudyEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:StudyArm ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:study_arms ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ak_schema:StudyArm ;
             owl:onProperty ak_schema:study_arms ],
         ak_schema:NamedThing ;
     skos:definition "An event that is part of the study design of an investigation." ;
@@ -8475,14 +8489,6 @@ ak_schema:immunogen a owl:ObjectProperty,
     rdfs:label "immunogen" ;
     rdfs:range ak_schema:string ;
     skos:definition "Antigen, vaccine or drug applied to subject at this intervention" ;
-    skos:inScheme <https://github.com/airr-knowledge/ak-schema> ;
-    ak_schema:nullable true .
-
-ak_schema:inclusion_exclusion_criteria a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "inclusion_exclusion_criteria" ;
-    rdfs:range ak_schema:string ;
-    skos:definition "List of criteria for inclusion/exclusion for the study" ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> ;
     ak_schema:nullable true .
 
@@ -9954,20 +9960,6 @@ ak_schema:datasets a owl:ObjectProperty,
     skos:definition "The datasets that support a conclusion" ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
-ak_schema:exclusion_criteria a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "exclusion_criteria" ;
-    rdfs:range ak_schema:string ;
-    skos:definition "Participants are excluded from an investigation if they meet this criteria" ;
-    skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
-
-ak_schema:inclusion_criteria a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "inclusion_criteria" ;
-    rdfs:range ak_schema:string ;
-    skos:definition "Participants in an investigation must meet this criteria" ;
-    skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
-
 ak_schema:participants a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "participants" ;
@@ -9994,13 +9986,13 @@ ak_schema:AKObject a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "AKObject" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:uriorcurie ;
+            owl:onProperty ak_schema:akc_id ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:akc_id ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty ak_schema:akc_id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:uriorcurie ;
             owl:onProperty ak_schema:akc_id ] ;
     skos:definition "Anything uniquely identifiable in the AKC." ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -10009,86 +10001,86 @@ ak_schema:LifeEvent a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "LifeEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:decimal ;
-            owl:onProperty ak_schema:start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:study_event ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:t0_event_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:study_event ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:t0_event_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:duration ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:t0_event ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:LifeEventProcessOntology ;
-            owl:onProperty ak_schema:life_event_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:decimal ;
-            owl:onProperty ak_schema:duration ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:time_unit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:time_unit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:geolocation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:life_event_type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:duration ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:t0_event ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:time_unit ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:geolocation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:participant ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:GeolocationOntology ;
-            owl:onProperty ak_schema:geolocation ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:life_event_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:participant ],
+            owl:onProperty ak_schema:duration ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:t0_event ],
+            owl:onProperty ak_schema:start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:t0_event_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:t0_event_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:participant ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:duration ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:decimal ;
+            owl:onProperty ak_schema:duration ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:time_unit ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Participant ;
             owl:onProperty ak_schema:participant ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:StudyEvent ;
             owl:onProperty ak_schema:study_event ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:GeolocationOntology ;
+            owl:onProperty ak_schema:geolocation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:decimal ;
+            owl:onProperty ak_schema:start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:time_unit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:geolocation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:t0_event ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:geolocation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:time_unit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:study_event ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:study_event ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:LifeEventProcessOntology ;
+            owl:onProperty ak_schema:life_event_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:t0_event_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:start ],
         ak_schema:NamedThing ;
     skos:definition "An event in which a study participant participates." ;
     skos:exactMatch BFO:0000015 ;
@@ -10098,104 +10090,104 @@ ak_schema:Participant a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Participant" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:phenotypic_sex ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:biological_sex ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:StrainEnum ;
-            owl:onProperty ak_schema:strain ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:AgeUnitOntology ;
-            owl:onProperty ak_schema:age_unit ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:species ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:age_unit ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:geolocation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:StudyArm ;
-            owl:onProperty ak_schema:study_arm ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:biological_sex ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:ethnicity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:species ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SpeciesOntology ;
-            owl:onProperty ak_schema:species ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:age ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:age_event ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:PhenotypicSexOntology ;
             owl:onProperty ak_schema:phenotypic_sex ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:race ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:race ],
+            owl:onProperty ak_schema:age_event ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:ethnicity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:ethnicity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:age ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:study_arm ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:age_unit ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:AgeUnitOntology ;
+            owl:onProperty ak_schema:age_unit ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:geolocation ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:race ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:strain ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ak_schema:StudyArm ;
             owl:onProperty ak_schema:study_arm ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:study_arm ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:phenotypic_sex ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:age_event ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:species ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:GeolocationOntology ;
             owl:onProperty ak_schema:geolocation ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:race ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:biological_sex ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:ethnicity ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:SpeciesOntology ;
+            owl:onProperty ak_schema:species ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:study_arm ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:age ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:BiologicalSexOntology ;
             owl:onProperty ak_schema:biological_sex ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:strain ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:age_event ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:strain ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:ethnicity ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:age ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:race ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:phenotypic_sex ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:age_event ],
+            owl:onProperty ak_schema:biological_sex ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:age_unit ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:age_unit ],
+            owl:onProperty ak_schema:strain ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:ethnicity ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:StrainEnum ;
+            owl:onProperty ak_schema:strain ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:geolocation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:race ],
         ak_schema:NamedThing ;
     skos:definition "A participant in an investigation." ;
     skos:exactMatch OBI:0100026 ;
@@ -10205,40 +10197,40 @@ ak_schema:Specimen a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Specimen" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:specimen_type ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:process ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ak_schema:tissue ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:specimen_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:specimen_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:process ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:process ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:life_event ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:tissue ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:TissueOntology ;
             owl:onProperty ak_schema:tissue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:process ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:specimen_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:process ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:specimen_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:specimen_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:LifeEvent ;
             owl:onProperty ak_schema:life_event ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:tissue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:tissue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:life_event ],
         ak_schema:NamedThing ;
     skos:exactMatch OBI:0100051 ;
@@ -10248,13 +10240,13 @@ ak_schema:SpecimenProcessing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SpecimenProcessing" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:specimen ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Specimen ;
             owl:onProperty ak_schema:specimen ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:specimen ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:specimen ],
         ak_schema:PlannedProcess ;
     skos:exactMatch OBI:0000094 ;
@@ -10264,26 +10256,14 @@ ak_schema:StudyArm a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "StudyArm" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:inclusion_criteria ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Investigation ;
             owl:onProperty ak_schema:investigation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:investigation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:inclusion_criteria ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:investigation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:exclusion_criteria ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:exclusion_criteria ],
+            owl:onProperty ak_schema:investigation ],
         ak_schema:NamedThing ;
     skos:definition "A population of participants of an investigation." ;
     skos:exactMatch OBI:0000181 ;
@@ -10312,13 +10292,13 @@ ak_schema:Epitope a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Epitope" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:type ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:type ],
         ak_schema:NamedThing ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -10345,35 +10325,17 @@ ak_schema:Investigation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Investigation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:StudyTypeOntology ;
-            owl:onProperty ak_schema:study_type ],
+            owl:allValuesFrom ak_schema:datetime ;
+            owl:onProperty ak_schema:update_date ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:inclusion_criteria ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:exclusion_criteria ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ak_schema:uriorcurie ;
             owl:onProperty ak_schema:archival_id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:exclusion_criteria ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:Conclusion ;
-            owl:onProperty ak_schema:conclusions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:participants ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:assays ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Simulation ;
             owl:onProperty ak_schema:simulations ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:uriorcurie ;
-            owl:onProperty ak_schema:archival_id ],
+            owl:allValuesFrom ak_schema:datetime ;
+            owl:onProperty ak_schema:release_date ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:Assay ;
             owl:onProperty ak_schema:assays ],
@@ -10381,38 +10343,53 @@ ak_schema:Investigation a owl:Class,
             owl:allValuesFrom ak_schema:Reference ;
             owl:onProperty ak_schema:documents ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:simulations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:study_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:datetime ;
-            owl:onProperty ak_schema:release_date ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:update_date ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:inclusion_criteria ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:release_date ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:study_type ],
+            owl:onProperty ak_schema:archival_id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:conclusions ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:update_date ],
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:inclusion_exclusion_criteria ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:release_date ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:participants ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:study_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:study_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:inclusion_exclusion_criteria ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:archival_id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:datetime ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:update_date ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:inclusion_exclusion_criteria ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:simulations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:assays ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:update_date ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:StudyTypeOntology ;
+            owl:onProperty ak_schema:study_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:Conclusion ;
+            owl:onProperty ak_schema:conclusions ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:documents ],
@@ -10459,10 +10436,10 @@ ak_schema:TCellReceptor a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:type ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:type ],
         ak_schema:AKObject ;
     skos:exactMatch GO:0042101 ;
@@ -10691,6 +10668,14 @@ ak_schema:germline_alignment_aa a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "germline_alignment_aa" ;
     rdfs:range ak_schema:string ;
+    skos:inScheme <https://github.com/airr-knowledge/ak-schema> ;
+    ak_schema:nullable true .
+
+ak_schema:inclusion_exclusion_criteria a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "inclusion_exclusion_criteria" ;
+    rdfs:range ak_schema:string ;
+    skos:definition "List of criteria for inclusion/exclusion for the study" ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> ;
     ak_schema:nullable true .
 
@@ -11047,11 +11032,8 @@ ak_schema:Assay a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Assay" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:specimen ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:assay_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:type ],
@@ -11059,20 +11041,11 @@ ak_schema:Assay a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:target_entity_type ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:type ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:assay_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:target_entity_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:specimen_processing ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:assay_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:target_entity_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:type ],
@@ -11080,14 +11053,26 @@ ak_schema:Assay a owl:Class,
             owl:allValuesFrom ak_schema:Specimen ;
             owl:onProperty ak_schema:specimen ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:SpecimenProcessing ;
-            owl:onProperty ak_schema:specimen_processing ],
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:specimen ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:assay_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:type ],
+            owl:onProperty ak_schema:assay_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:specimen_processing ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:target_entity_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:specimen ],
+            owl:onProperty ak_schema:target_entity_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:SpecimenProcessing ;
+            owl:onProperty ak_schema:specimen_processing ],
         ak_schema:PlannedProcess ;
     skos:exactMatch OBI:0000070 ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
@@ -11499,6 +11484,9 @@ ak_schema:NamedThing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "NamedThing" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:name ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:name ],
         [ a owl:Restriction ;
@@ -11509,12 +11497,9 @@ ak_schema:NamedThing a owl:Class,
             owl:onProperty ak_schema:description ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:description ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:name ],
         ak_schema:AKObject ;
     skos:definition "Name and description for AKC things." ;
@@ -11618,194 +11603,194 @@ ak_schema:Chain a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Chain" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:ChainTypeEnum ;
-            owl:onProperty ak_schema:chain_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:v_call ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr2_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr1_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:c_call ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr1_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:d_call ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr2_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:c_call ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:junction_aa_vj_gene_hash ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr2_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr1_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:j_call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:j_call ],
+            owl:onProperty ak_schema:cdr1_end ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ak_schema:cdr3_end ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:junction_aa_vj_allele_hash ],
+            owl:onProperty ak_schema:v_call ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cdr1_aa ],
+            owl:onProperty ak_schema:cdr2_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr2_end ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:cdr1_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr3_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr1_end ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
             owl:onProperty ak_schema:sequence_aa ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:aa_hash ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:junction_aa_vj_gene_hash ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:complete_vdj ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:chain_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
             owl:onProperty ak_schema:cdr3_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr2_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:junction_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:chain_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr1_end ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:aa_hash ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr3_start ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr1_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr3_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr3_aa ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr1_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr3_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr2_start ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:junction_aa_vj_allele_hash ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:d_call ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:integer ;
-            owl:onProperty ak_schema:cdr2_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:c_call ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:v_call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:complete_vdj ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:d_call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr3_start ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr2_end ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:cdr3_aa ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:boolean ;
             owl:onProperty ak_schema:complete_vdj ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:junction_aa_vj_gene_hash ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:cdr2_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:sequence ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:sequence_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence_aa ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ak_schema:junction_aa ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ak_schema:string ;
-            owl:onProperty ak_schema:j_call ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ak_schema:junction_aa_vj_allele_hash ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:aa_hash ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cdr3_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ak_schema:junction_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:v_call ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr3_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:v_call ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:cdr1_end ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ak_schema:aa_hash ],
+            owl:onProperty ak_schema:c_call ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ak_schema:sequence ],
+            owl:onProperty ak_schema:d_call ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ak_schema:cdr2_aa ],
         [ a owl:Restriction ;
             owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:c_call ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr3_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:complete_vdj ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:cdr1_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:j_call ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr3_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:junction_aa_vj_gene_hash ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:junction_aa_vj_gene_hash ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr3_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr2_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:j_call ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:j_call ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr1_end ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr1_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:junction_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:c_call ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:ChainTypeEnum ;
+            owl:onProperty ak_schema:chain_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:chain_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:sequence ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:sequence_aa ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ak_schema:cdr3_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:d_call ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr2_end ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr1_start ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:junction_aa_vj_allele_hash ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:complete_vdj ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:d_call ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:aa_hash ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:chain_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:string ;
+            owl:onProperty ak_schema:junction_aa_vj_gene_hash ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr1_aa ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ak_schema:integer ;
+            owl:onProperty ak_schema:cdr2_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:aa_hash ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr2_start ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:cdr2_end ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ak_schema:junction_aa ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:junction_aa_vj_allele_hash ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr2_start ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ak_schema:cdr1_aa ],
         ak_schema:AKObject ;
     skos:inScheme <https://github.com/airr-knowledge/ak-schema> .
 
@@ -11988,29 +11973,9 @@ ak_schema:string a owl:Class,
     skos:definition "Common data model schema for the AIRR Knowledge Commons" .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf ak_schema:Assay ;
-    owl:onProperty ak_schema:type ;
-    owl:someValuesFrom ak_schema:Assay .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf ak_schema:AIRRSequencingAssay ;
-    owl:onProperty ak_schema:type ;
-    owl:someValuesFrom ak_schema:AIRRSequencingAssay .
-
-[] a owl:Restriction ;
     rdfs:subClassOf ak_schema:TCellReceptor ;
     owl:onProperty ak_schema:type ;
     owl:someValuesFrom ak_schema:TCellReceptor .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf ak_schema:Epitope ;
-    owl:onProperty ak_schema:type ;
-    owl:someValuesFrom ak_schema:Epitope .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf ak_schema:TCellReceptorEpitopeBindingAssay ;
-    owl:onProperty ak_schema:type ;
-    owl:someValuesFrom ak_schema:TCellReceptorEpitopeBindingAssay .
 
 [] a owl:Restriction ;
     rdfs:subClassOf ak_schema:PeptidicEpitope ;
@@ -12018,12 +11983,32 @@ ak_schema:string a owl:Class,
     owl:someValuesFrom ak_schema:PeptidicEpitope .
 
 [] a owl:Restriction ;
+    rdfs:subClassOf ak_schema:AlphaBetaTCR ;
+    owl:onProperty ak_schema:type ;
+    owl:someValuesFrom ak_schema:AlphaBetaTCR .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf ak_schema:TCellReceptorEpitopeBindingAssay ;
+    owl:onProperty ak_schema:type ;
+    owl:someValuesFrom ak_schema:TCellReceptorEpitopeBindingAssay .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf ak_schema:AIRRSequencingAssay ;
+    owl:onProperty ak_schema:type ;
+    owl:someValuesFrom ak_schema:AIRRSequencingAssay .
+
+[] a owl:Restriction ;
     rdfs:subClassOf ak_schema:GammaDeltaTCR ;
     owl:onProperty ak_schema:type ;
     owl:someValuesFrom ak_schema:GammaDeltaTCR .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf ak_schema:AlphaBetaTCR ;
+    rdfs:subClassOf ak_schema:Epitope ;
     owl:onProperty ak_schema:type ;
-    owl:someValuesFrom ak_schema:AlphaBetaTCR .
+    owl:someValuesFrom ak_schema:Epitope .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf ak_schema:Assay ;
+    owl:onProperty ak_schema:type ;
+    owl:someValuesFrom ak_schema:Assay .
 

--- a/src/ak_schema/datamodel/ak_schema.py
+++ b/src/ak_schema/datamodel/ak_schema.py
@@ -1,5 +1,5 @@
 # Auto generated from ak_schema.yaml by pythongen.py version: 0.0.1
-# Generation date: 2025-03-12T22:22:22
+# Generation date: 2025-03-12T23:44:11
 # Schema: ak-schema
 #
 # id: https://github.com/airr-knowledge/ak-schema
@@ -604,8 +604,7 @@ class Investigation(PlannedProcess):
     akc_id: Union[str, InvestigationAkcId] = None
     study_type: Optional[Union[str, "StudyTypeOntology"]] = None
     archival_id: Optional[Union[str, URIorCURIE]] = None
-    inclusion_criteria: Optional[Union[str, List[str]]] = empty_list()
-    exclusion_criteria: Optional[Union[str, List[str]]] = empty_list()
+    inclusion_exclusion_criteria: Optional[str] = None
     release_date: Optional[Union[str, XSDDateTime]] = None
     update_date: Optional[Union[str, XSDDateTime]] = None
     participants: Optional[Union[Union[str, ParticipantAkcId], List[Union[str, ParticipantAkcId]]]] = empty_list()
@@ -623,13 +622,8 @@ class Investigation(PlannedProcess):
         if self.archival_id is not None and not isinstance(self.archival_id, URIorCURIE):
             self.archival_id = URIorCURIE(self.archival_id)
 
-        if not isinstance(self.inclusion_criteria, list):
-            self.inclusion_criteria = [self.inclusion_criteria] if self.inclusion_criteria is not None else []
-        self.inclusion_criteria = [v if isinstance(v, str) else str(v) for v in self.inclusion_criteria]
-
-        if not isinstance(self.exclusion_criteria, list):
-            self.exclusion_criteria = [self.exclusion_criteria] if self.exclusion_criteria is not None else []
-        self.exclusion_criteria = [v if isinstance(v, str) else str(v) for v in self.exclusion_criteria]
+        if self.inclusion_exclusion_criteria is not None and not isinstance(self.inclusion_exclusion_criteria, str):
+            self.inclusion_exclusion_criteria = str(self.inclusion_exclusion_criteria)
 
         if self.release_date is not None and not isinstance(self.release_date, XSDDateTime):
             self.release_date = XSDDateTime(self.release_date)
@@ -736,8 +730,6 @@ class StudyArm(NamedThing):
 
     akc_id: Union[str, StudyArmAkcId] = None
     investigation: Optional[Union[str, InvestigationAkcId]] = None
-    inclusion_criteria: Optional[Union[str, List[str]]] = empty_list()
-    exclusion_criteria: Optional[Union[str, List[str]]] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.akc_id):
@@ -747,14 +739,6 @@ class StudyArm(NamedThing):
 
         if self.investigation is not None and not isinstance(self.investigation, InvestigationAkcId):
             self.investigation = InvestigationAkcId(self.investigation)
-
-        if not isinstance(self.inclusion_criteria, list):
-            self.inclusion_criteria = [self.inclusion_criteria] if self.inclusion_criteria is not None else []
-        self.inclusion_criteria = [v if isinstance(v, str) else str(v) for v in self.inclusion_criteria]
-
-        if not isinstance(self.exclusion_criteria, list):
-            self.exclusion_criteria = [self.exclusion_criteria] if self.exclusion_criteria is not None else []
-        self.exclusion_criteria = [v if isinstance(v, str) else str(v) for v in self.exclusion_criteria]
 
         super().__post_init__(**kwargs)
 

--- a/src/ak_schema/schema/ak_study_design.yaml
+++ b/src/ak_schema/schema/ak_study_design.yaml
@@ -12,8 +12,7 @@ classes:
     slots:
       - study_type
       - archival_id
-      - inclusion_criteria
-      - exclusion_criteria
+      - inclusion_exclusion_criteria
       - release_date
       - update_date
       - participants
@@ -47,8 +46,6 @@ classes:
       A population of participants of an investigation.
     slots:
       - investigation
-      - inclusion_criteria
-      - exclusion_criteria
 
   Participant:
     is_a: NamedThing


### PR DESCRIPTION
- Slot on `Investigation` will use AIRR slot `inclusion_exclusion_criteria`
- Remove slots on `StudyArm`, the `description` slot should be used, e.g. when converting the StudyArm description from ImmuneSpace
